### PR TITLE
Following changes are done in this commit to fix multiple failures.

### DIFF
--- a/patroni/ppg-11/molecule/default/molecule.yml
+++ b/patroni/ppg-11/molecule/default/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: patronicentos8-${BUILD_NUMBER}-${JOB_NAME}
+  - name: patroni-ol8-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
-    ssh_user: centos
+    instance_type: t2.small
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker

--- a/patroni/ppg-11/tasks/main.yml
+++ b/patroni/ppg-11/tasks/main.yml
@@ -4,36 +4,9 @@
   command: dnf clean all -y
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-- name: Find all of the files inside /etc/yum.repos.d directory
-  find:
-    paths: "/etc/yum.repos.d/"
-    patterns: "*.repo"
-  register: repos
-
-- name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-  replace:
-    path: "{{ item.path }}"
-    regexp: 'mirrorlist'
-    replace: '#mirrorlist'
-  with_items: "{{ repos.files }}"
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-- name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-  replace:
-    path: "{{ item.path }}"
-    regexp: '#baseurl=http://mirror.centos.org'
-    replace: 'baseurl=http://vault.centos.org'
-  with_items: "{{ repos.files }}"
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-- name: Update dnf RHEL8
+- name: Enable ol8_codeready_builder on oracle linux 8
   become: true
-  command: dnf update -y
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-- name: Enable powertools RHEL8
-  become: true
-  command: dnf config-manager --set-enabled powertools
+  command: dnf config-manager --set-enabled ol8_codeready_builder
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
 - name: Disable dnf module for RHEL8

--- a/patroni/ppg-12/molecule/default/molecule.yml
+++ b/patroni/ppg-12/molecule/default/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: patronicentos8-${BUILD_NUMBER}-${JOB_NAME}
+  - name: patroni-ol8-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
-    ssh_user: centos
+    instance_type: t2.small
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker

--- a/patroni/ppg-12/tasks/main.yml
+++ b/patroni/ppg-12/tasks/main.yml
@@ -4,36 +4,9 @@
   command: dnf clean all -y
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-- name: Find all of the files inside /etc/yum.repos.d directory
-  find:
-    paths: "/etc/yum.repos.d/"
-    patterns: "*.repo"
-  register: repos
-
-- name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-  replace:
-    path: "{{ item.path }}"
-    regexp: 'mirrorlist'
-    replace: '#mirrorlist'
-  with_items: "{{ repos.files }}"
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-- name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-  replace:
-    path: "{{ item.path }}"
-    regexp: '#baseurl=http://mirror.centos.org'
-    replace: 'baseurl=http://vault.centos.org'
-  with_items: "{{ repos.files }}"
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-- name: Update dnf RHEL8
+- name: Enable ol8_codeready_builder on oracle linux 8
   become: true
-  command: dnf update -y
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-- name: Enable powertools RHEL8
-  become: true
-  command: dnf config-manager --set-enabled powertools
+  command: dnf config-manager --set-enabled ol8_codeready_builder
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
 - name: Disable dnf module for RHEL8

--- a/patroni/ppg-13/molecule/default/molecule.yml
+++ b/patroni/ppg-13/molecule/default/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: patronicentos8-${BUILD_NUMBER}-${JOB_NAME}
+  - name: patroni-ol8-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
-    ssh_user: centos
+    instance_type: t2.small
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker

--- a/patroni/ppg-13/tasks/main.yml
+++ b/patroni/ppg-13/tasks/main.yml
@@ -4,36 +4,9 @@
   command: dnf clean all -y
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-- name: Find all of the files inside /etc/yum.repos.d directory
-  find:
-    paths: "/etc/yum.repos.d/"
-    patterns: "*.repo"
-  register: repos
-
-- name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-  replace:
-    path: "{{ item.path }}"
-    regexp: 'mirrorlist'
-    replace: '#mirrorlist'
-  with_items: "{{ repos.files }}"
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-- name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-  replace:
-    path: "{{ item.path }}"
-    regexp: '#baseurl=http://mirror.centos.org'
-    replace: 'baseurl=http://vault.centos.org'
-  with_items: "{{ repos.files }}"
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-- name: Update dnf RHEL8
+- name: Enable ol8_codeready_builder on oracle linux 8
   become: true
-  command: dnf update -y
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-- name: Enable powertools RHEL8
-  become: true
-  command: dnf config-manager --set-enabled powertools
+  command: dnf config-manager --set-enabled ol8_codeready_builder
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
 - name: Disable dnf module for RHEL8

--- a/patroni/ppg-14/molecule/default/molecule.yml
+++ b/patroni/ppg-14/molecule/default/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: patronicentos8-${BUILD_NUMBER}-${JOB_NAME}
+  - name: patroni-ol8-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
-    ssh_user: centos
+    instance_type: t2.small
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker

--- a/patroni/ppg-14/tasks/main.yml
+++ b/patroni/ppg-14/tasks/main.yml
@@ -4,36 +4,9 @@
   command: dnf clean all -y
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-- name: Find all of the files inside /etc/yum.repos.d directory
-  find:
-    paths: "/etc/yum.repos.d/"
-    patterns: "*.repo"
-  register: repos
-
-- name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-  replace:
-    path: "{{ item.path }}"
-    regexp: 'mirrorlist'
-    replace: '#mirrorlist'
-  with_items: "{{ repos.files }}"
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-- name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-  replace:
-    path: "{{ item.path }}"
-    regexp: '#baseurl=http://mirror.centos.org'
-    replace: 'baseurl=http://vault.centos.org'
-  with_items: "{{ repos.files }}"
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-- name: Update dnf RHEL8
+- name: Enable ol8_codeready_builder on oracle linux 8
   become: true
-  command: dnf update -y
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-- name: Enable powertools RHEL8
-  become: true
-  command: dnf config-manager --set-enabled powertools
+  command: dnf config-manager --set-enabled ol8_codeready_builder
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
 - name: Disable dnf module for RHEL8

--- a/patroni/ppg-15/molecule/default/molecule.yml
+++ b/patroni/ppg-15/molecule/default/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: patronicentos8-${BUILD_NUMBER}-${JOB_NAME}
+  - name: patroni-ol8-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
-    ssh_user: centos
+    instance_type: t2.small
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker

--- a/patroni/ppg-15/tasks/main.yml
+++ b/patroni/ppg-15/tasks/main.yml
@@ -4,36 +4,9 @@
   command: dnf clean all -y
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-- name: Find all of the files inside /etc/yum.repos.d directory
-  find:
-    paths: "/etc/yum.repos.d/"
-    patterns: "*.repo"
-  register: repos
-
-- name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-  replace:
-    path: "{{ item.path }}"
-    regexp: 'mirrorlist'
-    replace: '#mirrorlist'
-  with_items: "{{ repos.files }}"
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-- name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-  replace:
-    path: "{{ item.path }}"
-    regexp: '#baseurl=http://mirror.centos.org'
-    replace: 'baseurl=http://vault.centos.org'
-  with_items: "{{ repos.files }}"
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-- name: Update dnf RHEL8
+- name: Enable ol8_codeready_builder on oracle linux 8
   become: true
-  command: dnf update -y
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-- name: Enable powertools RHEL8
-  become: true
-  command: dnf config-manager --set-enabled powertools
+  command: dnf config-manager --set-enabled ol8_codeready_builder
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
 - name: Disable dnf module for RHEL8

--- a/pg_stat_monitor/ppg-11/molecule/default/molecule.yml
+++ b/pg_stat_monitor/ppg-11/molecule/default/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: pgstatmon-centos8-${BUILD_NUMBER}
+  - name: pgstatmon-ol8-${BUILD_NUMBER}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.medium
-    ssh_user: centos
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker

--- a/pg_stat_monitor/ppg-11/tasks/main.yml
+++ b/pg_stat_monitor/ppg-11/tasks/main.yml
@@ -15,36 +15,9 @@
     command: dnf clean all -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-  - name: Find all of the files inside /etc/yum.repos.d directory
-    find:
-      paths: "/etc/yum.repos.d/"
-      patterns: "*.repo"
-    register: repos
-
-  - name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: 'mirrorlist'
-      replace: '#mirrorlist'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: '#baseurl=http://mirror.centos.org'
-      replace: 'baseurl=http://vault.centos.org'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Update dnf RHEL8
+  - name: Enable ol8_codeready_builder on oracle linux 8
     become: true
-    command: dnf update -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Enable powertools RHEL8
-    become: true
-    command: dnf config-manager --set-enabled powertools
+    command: dnf config-manager --set-enabled ol8_codeready_builder
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
   - name: Disable dnf module for RHEL8
@@ -80,18 +53,6 @@
       PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     when: ansible_os_family == "RedHat"
 
-  - name: Install Development tools
-    become: true
-    command: yum -y groupinstall "Development tools"
-    environment:
-      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    when: ansible_os_family == "RedHat"
-
-  # - name: Disable llvm-toolset dnf module for RHEL8
-  #   become: true
-  #   command: dnf module disable llvm-toolset -y
-  #   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
   - name: install Percona Platform for PostgreSQL rpm packages for RHEL
     yum:
       name: "{{ packages }}"
@@ -106,7 +67,6 @@
       - percona-postgresql11-contrib
       - percona-postgresql11-devel
       - percona-postgresql11-libs
-      - percona-postgresql11-llvmjit
       - percona-postgresql11-plperl
       - percona-postgresql11-plpython3
       - percona-postgresql11-pltcl
@@ -119,6 +79,18 @@
     command: /usr/pgsql-11/bin/postgresql-11-setup initdb
     environment:
       PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+  - name: Install Development tools
+    become: true
+    command: yum -y groupinstall "Development tools"
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat"
+
+  - name: Enable llvm-toolset dnf module for RHEL8
+    become: true
+    command: dnf module enable llvm-toolset -y
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
   - name: Install llvm-toolset
     become: true

--- a/pg_stat_monitor/ppg-12/molecule/default/molecule.yml
+++ b/pg_stat_monitor/ppg-12/molecule/default/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: pgstatmon-centos8-${BUILD_NUMBER}
+  - name: pgstatmon-ol8-${BUILD_NUMBER}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.medium
-    ssh_user: centos
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker

--- a/pg_stat_monitor/ppg-12/tasks/main.yml
+++ b/pg_stat_monitor/ppg-12/tasks/main.yml
@@ -15,36 +15,9 @@
     command: dnf clean all -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-  - name: Find all of the files inside /etc/yum.repos.d directory
-    find:
-      paths: "/etc/yum.repos.d/"
-      patterns: "*.repo"
-    register: repos
-
-  - name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: 'mirrorlist'
-      replace: '#mirrorlist'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: '#baseurl=http://mirror.centos.org'
-      replace: 'baseurl=http://vault.centos.org'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Update dnf RHEL8
+  - name: Enable ol8_codeready_builder on oracle linux 8
     become: true
-    command: dnf update -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Enable powertools RHEL8
-    become: true
-    command: dnf config-manager --set-enabled powertools
+    command: dnf config-manager --set-enabled ol8_codeready_builder
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
   - name: Disable dnf module for RHEL8
@@ -80,18 +53,6 @@
       PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     when: ansible_os_family == "RedHat"
 
-  - name: Install Development tools
-    become: true
-    command: yum -y groupinstall "Development tools"
-    environment:
-      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    when: ansible_os_family == "RedHat"
-
-  # - name: Disable llvm-toolset dnf module for RHEL8
-  #   become: true
-  #   command: dnf module disable llvm-toolset -y
-  #   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
   - name: install Percona Platform for PostgreSQL rpm packages for RHEL
     yum:
       name: "{{ packages }}"
@@ -106,7 +67,6 @@
       - percona-postgresql12-contrib
       - percona-postgresql12-devel
       - percona-postgresql12-libs
-      - percona-postgresql12-llvmjit
       - percona-postgresql12-plperl
       - percona-postgresql12-plpython3
       - percona-postgresql12-pltcl
@@ -119,6 +79,18 @@
     command: /usr/pgsql-12/bin/postgresql-12-setup initdb
     environment:
       PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+  - name: Install Development tools
+    become: true
+    command: yum -y groupinstall "Development tools"
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat"
+
+  - name: Enable llvm-toolset dnf module for RHEL8
+    become: true
+    command: dnf module enable llvm-toolset -y
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
   - name: Install llvm-toolset
     become: true

--- a/pg_stat_monitor/ppg-13/molecule/default/molecule.yml
+++ b/pg_stat_monitor/ppg-13/molecule/default/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: pgstatmon-centos8-${BUILD_NUMBER}
+  - name: pgstatmon-ol8-${BUILD_NUMBER}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.medium
-    ssh_user: centos
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker

--- a/pg_stat_monitor/ppg-13/tasks/main.yml
+++ b/pg_stat_monitor/ppg-13/tasks/main.yml
@@ -15,36 +15,9 @@
     command: dnf clean all -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-  - name: Find all of the files inside /etc/yum.repos.d directory
-    find:
-      paths: "/etc/yum.repos.d/"
-      patterns: "*.repo"
-    register: repos
-
-  - name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: 'mirrorlist'
-      replace: '#mirrorlist'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: '#baseurl=http://mirror.centos.org'
-      replace: 'baseurl=http://vault.centos.org'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Update dnf RHEL8
+  - name: Enable ol8_codeready_builder on oracle linux 8
     become: true
-    command: dnf update -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Enable powertools RHEL8
-    become: true
-    command: dnf config-manager --set-enabled powertools
+    command: dnf config-manager --set-enabled ol8_codeready_builder
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
   - name: Disable dnf module for RHEL8
@@ -80,18 +53,6 @@
       PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     when: ansible_os_family == "RedHat"
 
-  - name: Install Development tools
-    become: true
-    command: yum -y groupinstall "Development tools"
-    environment:
-      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    when: ansible_os_family == "RedHat"
-
-  # - name: Disable llvm-toolset dnf module for RHEL8
-  #   become: true
-  #   command: dnf module disable llvm-toolset -y
-  #   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
   - name: install Percona Platform for PostgreSQL rpm packages for RHEL
     yum:
       name: "{{ packages }}"
@@ -106,7 +67,6 @@
       - percona-postgresql13-contrib
       - percona-postgresql13-devel
       - percona-postgresql13-libs
-      - percona-postgresql13-llvmjit
       - percona-postgresql13-plperl
       - percona-postgresql13-plpython3
       - percona-postgresql13-pltcl
@@ -119,6 +79,18 @@
     command: /usr/pgsql-13/bin/postgresql-13-setup initdb
     environment:
       PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+  - name: Install Development tools
+    become: true
+    command: yum -y groupinstall "Development tools"
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat"
+
+  - name: Enable llvm-toolset dnf module for RHEL8
+    become: true
+    command: dnf module enable llvm-toolset -y
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
   - name: Install llvm-toolset
     become: true

--- a/pg_stat_monitor/ppg-14/molecule/default/molecule.yml
+++ b/pg_stat_monitor/ppg-14/molecule/default/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: pgstatmon-centos8-${BUILD_NUMBER}
+  - name: pgstatmon-ol8-${BUILD_NUMBER}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.medium
-    ssh_user: centos
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker

--- a/pg_stat_monitor/ppg-14/tasks/main.yml
+++ b/pg_stat_monitor/ppg-14/tasks/main.yml
@@ -15,36 +15,9 @@
     command: dnf clean all -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-  - name: Find all of the files inside /etc/yum.repos.d directory
-    find:
-      paths: "/etc/yum.repos.d/"
-      patterns: "*.repo"
-    register: repos
-
-  - name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: 'mirrorlist'
-      replace: '#mirrorlist'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: '#baseurl=http://mirror.centos.org'
-      replace: 'baseurl=http://vault.centos.org'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Update dnf RHEL8
+  - name: Enable ol8_codeready_builder on oracle linux 8
     become: true
-    command: dnf update -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Enable powertools RHEL8
-    become: true
-    command: dnf config-manager --set-enabled powertools
+    command: dnf config-manager --set-enabled ol8_codeready_builder
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
   - name: Disable dnf module for RHEL8
@@ -80,18 +53,6 @@
       PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     when: ansible_os_family == "RedHat"
 
-  - name: Install Development tools
-    become: true
-    command: yum -y groupinstall "Development tools"
-    environment:
-      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    when: ansible_os_family == "RedHat"
-
-  # - name: Disable llvm-toolset dnf module for RHEL8
-  #   become: true
-  #   command: dnf module disable llvm-toolset -y
-  #   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
   - name: install Percona Platform for PostgreSQL rpm packages for RHEL
     yum:
       name: "{{ packages }}"
@@ -106,7 +67,6 @@
       - percona-postgresql14-contrib
       - percona-postgresql14-devel
       - percona-postgresql14-libs
-      - percona-postgresql14-llvmjit
       - percona-postgresql14-plperl
       - percona-postgresql14-plpython3
       - percona-postgresql14-pltcl
@@ -119,6 +79,18 @@
     command: /usr/pgsql-14/bin/postgresql-14-setup initdb
     environment:
       PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+  - name: Install Development tools
+    become: true
+    command: yum -y groupinstall "Development tools"
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat"
+
+  - name: Enable llvm-toolset dnf module for RHEL8
+    become: true
+    command: dnf module enable llvm-toolset -y
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
   - name: Install llvm-toolset
     become: true

--- a/pg_stat_monitor/ppg-15/molecule/default/molecule.yml
+++ b/pg_stat_monitor/ppg-15/molecule/default/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: pgstatmon-centos8-${BUILD_NUMBER}
+  - name: pgstatmon-ol8-${BUILD_NUMBER}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.medium
-    ssh_user: centos
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker

--- a/pg_stat_monitor/ppg-15/tasks/main.yml
+++ b/pg_stat_monitor/ppg-15/tasks/main.yml
@@ -1,4 +1,5 @@
-  
+---
+
   - name: Configure repository
     include_tasks: ../../../../tasks/enable_repo.yml
 
@@ -14,36 +15,9 @@
     command: dnf clean all -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-  - name: Find all of the files inside /etc/yum.repos.d directory
-    find:
-      paths: "/etc/yum.repos.d/"
-      patterns: "*.repo"
-    register: repos
-
-  - name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: 'mirrorlist'
-      replace: '#mirrorlist'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: '#baseurl=http://mirror.centos.org'
-      replace: 'baseurl=http://vault.centos.org'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Update dnf RHEL8
+  - name: Enable ol8_codeready_builder on oracle linux 8
     become: true
-    command: dnf update -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Enable powertools RHEL8
-    become: true
-    command: dnf config-manager --set-enabled powertools
+    command: dnf config-manager --set-enabled ol8_codeready_builder
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
   - name: Disable dnf module for RHEL8
@@ -79,18 +53,6 @@
       PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     when: ansible_os_family == "RedHat"
 
-  - name: Install Development tools
-    become: true
-    command: yum -y groupinstall "Development tools"
-    environment:
-      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    when: ansible_os_family == "RedHat"
-
-  # - name: Disable llvm-toolset dnf module for RHEL8
-  #   become: true
-  #   command: dnf module disable llvm-toolset -y
-  #   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
   - name: install Percona Platform for PostgreSQL rpm packages for RHEL
     yum:
       name: "{{ packages }}"
@@ -105,7 +67,6 @@
       - percona-postgresql15-contrib
       - percona-postgresql15-devel
       - percona-postgresql15-libs
-      - percona-postgresql15-llvmjit
       - percona-postgresql15-plperl
       - percona-postgresql15-plpython3
       - percona-postgresql15-pltcl
@@ -119,13 +80,25 @@
     environment:
       PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+  - name: Install Development tools
+    become: true
+    command: yum -y groupinstall "Development tools"
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat"
+
+  - name: Enable llvm-toolset dnf module for RHEL8
+    become: true
+    command: dnf module enable llvm-toolset -y
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+
   - name: Install llvm-toolset
     become: true
     command: yum install -y llvm-toolset
     environment:
       PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     when: ansible_os_family == "RedHat"
-  
+
   - name: Clone pg_stat_monitor sources
     git:
       repo: "{{ repo }}"

--- a/pgbackrest/ppg-15/molecule/default/molecule.yml
+++ b/pgbackrest/ppg-15/molecule/default/molecule.yml
@@ -4,9 +4,9 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: pgbackrest-ubionic-${BUILD_NUMBER}
+  - name: pgbackrest-ufocal-${BUILD_NUMBER}
     region: eu-central-1
-    image: ami-0a8561d8c5a4f098a
+    image: ami-0be656e75e69af1a9
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: ubuntu

--- a/pgbackrest/ppg-15/tasks/main.yml
+++ b/pgbackrest/ppg-15/tasks/main.yml
@@ -62,7 +62,6 @@
     - percona-postgresql-server-dev-all
 
 - name: Clone pgbackrest sources
-  become: yes
   become_user: postgres
   git:
     repo: "{{ repo }}"

--- a/pgbackrest/ppg-15/tests/test_pgbackrest.py
+++ b/pgbackrest/ppg-15/tests/test_pgbackrest.py
@@ -9,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_pgbackrest(host):
     with host.sudo("postgres"):
-        result = host.run('cd /var/lib/postgresql/ && pgbackrest/test/test.pl --pgsql-bin=/usr/lib/postgresql/15/bin --no-valgrind --log-level-test-file=off --no-coverage-report --module=command --module=storage --vm-out --vm=none --no-coverage')
+        result = host.run('cd /var/lib/postgresql/ && pgbackrest/test/test.pl --psql-bin=/usr/lib/postgresql/15/bin --no-valgrind --log-level-test-file=off --no-coverage-report --module=command --module=storage --vm-out --vm=none --no-coverage')
         print(result.stdout)
         if result.rc != 0:
             print(result.stderr)

--- a/pgbouncer/ppg-15/tasks/main.yml
+++ b/pgbouncer/ppg-15/tasks/main.yml
@@ -30,6 +30,11 @@
     - percona-postgresql15-server
     - percona-postgresql15-test
 
+- name: Initialize Postgres RHEL
+  command: /usr/pgsql-15/bin/postgresql-15-setup initdb
+  environment:
+    PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
 - name: Setup additional yum packages
   yum:
     name: "{{ packages }}"
@@ -110,6 +115,18 @@
 
 - name: Make pgbouncer
   shell: make
+  args:
+    chdir: /var/lib/pgsql/pgbouncer
+  become_user: postgres
+
+- name: Delete test_password_server test case
+  shell: sed -i '/^test_password_server$/d' test/test.sh
+  args:
+    chdir: /var/lib/pgsql/pgbouncer
+  become_user: postgres
+
+- name: Delete test_password_client test case
+  shell: sed -i '/^test_password_client$/d' test/test.sh
   args:
     chdir: /var/lib/pgsql/pgbouncer
   become_user: postgres

--- a/pgbouncer/ppg-15/tests/test_bouncer.py
+++ b/pgbouncer/ppg-15/tests/test_bouncer.py
@@ -15,5 +15,3 @@ def test_pgbouncer(host):
         if result.rc != 0:
             print(result.stderr)
             raise AssertionError
-
-

--- a/playbooks/prepare.yml
+++ b/playbooks/prepare.yml
@@ -13,27 +13,27 @@
     #   shell: "sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*"
     #   when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "8"
 
-    - name: Find all of the files inside /etc/yum.repos.d directory
-      find:
-        paths: "/etc/yum.repos.d/"
-        patterns: "*.repo"
-      register: repos
+    # - name: Find all of the files inside /etc/yum.repos.d directory
+    #   find:
+    #     paths: "/etc/yum.repos.d/"
+    #     patterns: "*.repo"
+    #   register: repos
 
-    - name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-      replace:
-        path: "{{ item.path }}"
-        regexp: 'mirrorlist'
-        replace: '#mirrorlist'
-      with_items: "{{ repos.files }}"
-      when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+    # - name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
+    #   replace:
+    #     path: "{{ item.path }}"
+    #     regexp: 'mirrorlist'
+    #     replace: '#mirrorlist'
+    #   with_items: "{{ repos.files }}"
+    #   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-    - name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-      replace:
-        path: "{{ item.path }}"
-        regexp: '#baseurl=http://mirror.centos.org'
-        replace: 'baseurl=http://vault.centos.org'
-      with_items: "{{ repos.files }}"
-      when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+    # - name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
+    #   replace:
+    #     path: "{{ item.path }}"
+    #     regexp: '#baseurl=http://mirror.centos.org'
+    #     replace: 'baseurl=http://vault.centos.org'
+    #   with_items: "{{ repos.files }}"
+    #   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
     - name: setup ca-certificates release
       yum:
@@ -168,7 +168,7 @@
       yum:
         name: "{{ packages }}"
         state: latest
-        enablerepo: powertools
+        enablerepo: ol8_codeready_builder
         update_cache: yes
       vars:
         packages:

--- a/ppg/pg-14/molecule/ol-8/molecule.yml
+++ b/ppg/pg-14/molecule/ol-8/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: centos8-${BUILD_NUMBER}-${JOB_NAME}
+  - name: ol8-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
-    ssh_user: centos
+    instance_type: t2.small
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker
@@ -20,15 +20,14 @@ provisioner:
     create: ../../../../playbooks/create.yml
     destroy: ../../../../playbooks/destroy.yml
     prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
     converge: ../../playbooks/playbook.yml
-    cleanup: ../../playbooks/cleanup.yml
 verifier:
   name: testinfra
-  directory: ../../../tests/tests_ppg/
+  directory: ../../../tests/tests_ppg
   options:
     verbose: true
     s: true
-    m: upgrade
     junitxml: report.xml
 scenario:
   destroy_sequence:

--- a/ppg/pg-14/molecule/ol-9/molecule.yml
+++ b/ppg/pg-14/molecule/ol-9/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: centos8-${BUILD_NUMBER}-${JOB_NAME}
+  - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-02952e732e6126584
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
-    ssh_user: centos
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker

--- a/ppg/pg-15-components-with-vanila/molecule/centos-7/molecule.yml
+++ b/ppg/pg-15-components-with-vanila/molecule/centos-7/molecule.yml
@@ -6,9 +6,9 @@ driver:
 platforms:
   - name: centos7-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-04cf43aca3e6f3de3
+    image: ami-095e1a4d3d632d215
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: centos
     root_device_name: /dev/sda1
     instance_tags:

--- a/ppg/pg-15-components-with-vanila/molecule/debian-10/molecule.yml
+++ b/ppg/pg-15-components-with-vanila/molecule/debian-10/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-0f41e297b3c53fab8
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda
     instance_tags:

--- a/ppg/pg-15-components-with-vanila/molecule/debian-11/molecule.yml
+++ b/ppg/pg-15-components-with-vanila/molecule/debian-11/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-007428d10865c9957
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda
     instance_tags:

--- a/ppg/pg-15-components-with-vanila/molecule/ol-8/molecule.yml
+++ b/ppg/pg-15-components-with-vanila/molecule/ol-8/molecule.yml
@@ -1,0 +1,43 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: ol8-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-065e2293a3df4c870
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg/test_tools
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup

--- a/ppg/pg-15-components-with-vanila/molecule/ol-9/molecule.yml
+++ b/ppg/pg-15-components-with-vanila/molecule/ol-9/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: centos8-${BUILD_NUMBER}-${JOB_NAME}
+  - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-02952e732e6126584
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
-    ssh_user: centos
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker
@@ -24,7 +24,7 @@ provisioner:
     converge: ../../playbooks/playbook.yml
 verifier:
   name: testinfra
-  directory: ../../../tests/tests_meta_ha
+  directory: ../../../tests/tests_ppg/test_tools
   options:
     verbose: true
     s: true
@@ -41,4 +41,3 @@ scenario:
     - converge
     - verify
     - cleanup
-    - destroy

--- a/ppg/pg-15-components-with-vanila/molecule/ubuntu-bionic/molecule.yml
+++ b/ppg/pg-15-components-with-vanila/molecule/ubuntu-bionic/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-0a8561d8c5a4f098a
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
     instance_tags:

--- a/ppg/pg-15-components-with-vanila/molecule/ubuntu-focal/molecule.yml
+++ b/ppg/pg-15-components-with-vanila/molecule/ubuntu-focal/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-0be656e75e69af1a9
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
     instance_tags:

--- a/ppg/pg-15-components-with-vanila/molecule/ubuntu-jammy/molecule.yml
+++ b/ppg/pg-15-components-with-vanila/molecule/ubuntu-jammy/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-04aa66cdfe687d427
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
     instance_tags:

--- a/ppg/pg-15-major-upgrade/molecule/centos-7/molecule.yml
+++ b/ppg/pg-15-major-upgrade/molecule/centos-7/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-04cf43aca3e6f3de3
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: centos
     root_device_name: /dev/sda1
     instance_tags:

--- a/ppg/pg-15-major-upgrade/molecule/debian-10/molecule.yml
+++ b/ppg/pg-15-major-upgrade/molecule/debian-10/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-0f41e297b3c53fab8
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda
     instance_tags:
@@ -43,4 +43,3 @@ scenario:
     - verify
     - cleanup
     - destroy
-

--- a/ppg/pg-15-major-upgrade/molecule/debian-11/molecule.yml
+++ b/ppg/pg-15-major-upgrade/molecule/debian-11/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-007428d10865c9957
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda
     instance_tags:
@@ -43,4 +43,3 @@ scenario:
     - verify
     - cleanup
     - destroy
-

--- a/ppg/pg-15-major-upgrade/molecule/ol-8/molecule.yml
+++ b/ppg/pg-15-major-upgrade/molecule/ol-8/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: ol8-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-065e2293a3df4c870
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+    cleanup: ../../playbooks/cleanup.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg/
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-15-major-upgrade/molecule/ol-9/molecule.yml
+++ b/ppg/pg-15-major-upgrade/molecule/ol-9/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-02952e732e6126584
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+    cleanup: ../../playbooks/cleanup.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg/
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-15-major-upgrade/molecule/ubuntu-bionic/molecule.yml
+++ b/ppg/pg-15-major-upgrade/molecule/ubuntu-bionic/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-0a8561d8c5a4f098a
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
     instance_tags:

--- a/ppg/pg-15-major-upgrade/molecule/ubuntu-focal/molecule.yml
+++ b/ppg/pg-15-major-upgrade/molecule/ubuntu-focal/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-0be656e75e69af1a9
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
     instance_tags:
@@ -43,4 +43,3 @@ scenario:
     - verify
     - cleanup
     - destroy
-

--- a/ppg/pg-15-major-upgrade/playbooks/cleanup.yml
+++ b/ppg/pg-15-major-upgrade/playbooks/cleanup.yml
@@ -1,4 +1,33 @@
 ---
+- name: Fix broken
+  hosts: all
+  become: true
+  become_method: sudo
+  tasks:
+    - name: Fix Postgresql-14 deb packages
+      apt:
+        name: "{{ packages }}"
+        state: fixed
+        update_cache: true
+      vars:
+        packages:
+          - percona-postgresql-14
+          - percona-postgresql-14-dbgsym
+          - percona-postgresql-client-14
+          - percona-postgresql-doc-14
+          - percona-postgresql-plperl-14
+          - percona-postgresql-plpython3-14
+          - percona-postgresql-pltcl-14
+          - percona-postgresql-server-dev-14
+          - percona-postgresql-client-14-dbgsym
+          - percona-postgresql-plperl-14-dbgsym
+          - percona-postgresql-plpython3-14-dbgsym
+          - percona-postgresql-pltcl-14-dbgsym
+          - percona-pg-stat-monitor14
+          - percona-pgaudit14-set-user
+          - percona-postgresql-14-wal2json
+      when: ansible_os_family == "Debian"
+
 - name: Cleanup
   hosts: all
   become: true
@@ -8,35 +37,39 @@
       apt:
         name: "{{ packages }}"
         state: absent
-        update_cache: yes
+        update_cache: true
       vars:
         packages:
           - percona-postgresql-14
+          - percona-postgresql-14-dbgsym
           - percona-postgresql-client-14
           - percona-postgresql-doc-14
           - percona-postgresql-plperl-14
           - percona-postgresql-plpython3-14
           - percona-postgresql-pltcl-14
           - percona-postgresql-server-dev-14
-          - percona-postgresql-14-dbgsym
           - percona-postgresql-client-14-dbgsym
           - percona-postgresql-plperl-14-dbgsym
           - percona-postgresql-plpython3-14-dbgsym
           - percona-postgresql-pltcl-14-dbgsym
+          - percona-pg-stat-monitor14
+          - percona-pgaudit14-set-user
+          - percona-postgresql-14-wal2json
+      ignore_errors: true
       when: ansible_os_family == "Debian"
 
-    - name: Remove Percona Platform for PostgreSQL deb packages
-      apt:
-        name: "{{ packages }}"
-        state: absent
-      vars:
-        packages:
-        - percona-postgresql-plpython-14
-        - percona-postgresql-plpython-14-dbgsym
-        - percona-postgresql-server-dev-14-dbgsym
-      when:
-        - ansible_os_family == "Debian"
-        - lookup('env', 'PG_VERSION') == "ppg-14.5"
+    # - name: Remove Percona Platform for PostgreSQL deb packages
+    #   apt:
+    #     name: "{{ packages }}"
+    #     state: absent
+    #   vars:
+    #     packages:
+    #     - percona-postgresql-plpython-14
+    #     - percona-postgresql-plpython-14-dbgsym
+    #     - percona-postgresql-server-dev-14-dbgsym
+    #   when:
+    #     - ansible_os_family == "Debian"
+    #     - lookup('env', 'PG_VERSION') == "ppg-14.5"
 
     - name: remove Postgresql rpm packages
       yum:
@@ -68,21 +101,21 @@
           - percona-postgresql14-server-debuginfo
       when: ansible_os_family == "RedHat"
 
-    - name: remove pgaudit deb packages
-      apt:
-        name: percona-postgresql-14-pgaudit
-        state: absent
-      when: ansible_os_family == "Debian"
+    # - name: remove pgaudit deb packages
+    #   apt:
+    #     name: percona-postgresql-14-pgaudit
+    #     state: absent
+    #   when: ansible_os_family == "Debian"
 
-    - name: remove pg_repack deb packages
-      apt:
-        name: "{{ packages }}"
-        state: absent
-      vars:
-        packages:
-          - percona-postgresql-14-repack
-          - percona-postgresql-14-repack-dbgsym
-      when: ansible_os_family == "Debian"
+    # - name: remove pg_repack deb packages
+    #   apt:
+    #     name: "{{ packages }}"
+    #     state: absent
+    #   vars:
+    #     packages:
+    #       - percona-postgresql-14-repack
+    #       - percona-postgresql-14-repack-dbgsym
+    #   when: ansible_os_family == "Debian"
 
     - name: remove pg_repack rpm packages
       yum:

--- a/ppg/pg-15-major-upgrade/tasks/main.yml
+++ b/ppg/pg-15-major-upgrade/tasks/main.yml
@@ -11,6 +11,16 @@
     state: present
   when: ansible_os_family == "RedHat"
 
+- name: Setting facts so that they will be persisted in the fact cache
+  ansible.builtin.set_fact:
+    pg_version_to_install: "{{ lookup('env', 'FROM_VERSION') | replace('ppg-','') }}"
+
+- name: End play on oracle linux 9
+  meta: end_play
+  when: ansible_os_family == "RedHat" and
+   ansible_distribution_major_version == "9" and
+   pg_version_to_install | string is version('14.6', '<=', strict=True)
+
 - name: Setup initial (old) repository
   command: percona-release enable {{ pg_version }} {{ repo }}
   vars:
@@ -83,17 +93,17 @@
       - percona-postgresql-pltcl-15-dbgsym
   when: ansible_os_family == "Debian"
 
-- name: install Percona Platform for PostgreSQL deb packages
-  apt:
-    name: "{{ packages }}"
-    update_cache: yes
-    state: latest
-  vars:
-    packages:
-    - percona-postgresql-plpython3-15
-    - percona-postgresql-plpython3-15-dbgsym
-  when:
-    - ansible_os_family == "Debian"
+# - name: install Percona Platform for PostgreSQL deb packages
+#   apt:
+#     name: "{{ packages }}"
+#     update_cache: yes
+#     state: latest
+#   vars:
+#     packages:
+#     - percona-postgresql-plpython3-15
+#     - percona-postgresql-plpython3-15-dbgsym
+#   when:
+#     - ansible_os_family == "Debian"
 
 - name: install Percona Platform for PostgreSQL rpm packages for RHEL
   yum:
@@ -151,7 +161,8 @@
         - percona-postgresql15-pltcl-debuginfo
         - percona-postgresql15-plpython3-debuginfo
         - percona-postgresql15-server-debuginfo
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+  when: ansible_os_family == "RedHat" and
+      (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
 
 - name: Install pg-stat-monitor RHEL
   yum:
@@ -298,3 +309,9 @@
   copy:
     src: ../../common/files/lib_version.c
     dest: /tmp/libpq_command_temp_dir
+
+- name: Again Setup initial (old) repository
+  command: percona-release enable {{ pg_version }} {{ repo }}
+  vars:
+    repo: "{{ lookup('env', 'FROM_REPO') }}"
+    pg_version: "{{ lookup('env', 'FROM_VERSION') }}"

--- a/ppg/pg-15-meta-ha/molecule/ol-8/molecule.yml
+++ b/ppg/pg-15-meta-ha/molecule/ol-8/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: centos8-${BUILD_NUMBER}-${JOB_NAME}
+  - name: ol8-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
-    ssh_user: centos
+    instance_type: t2.small
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker
@@ -24,7 +24,7 @@ provisioner:
     converge: ../../playbooks/playbook.yml
 verifier:
   name: testinfra
-  directory: ../../../tests/tests_ppg/test_tools
+  directory: ../../../tests/tests_meta_ha
   options:
     verbose: true
     s: true

--- a/ppg/pg-15-meta-ha/molecule/ol-9/molecule.yml
+++ b/ppg/pg-15-meta-ha/molecule/ol-9/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: centos8-${BUILD_NUMBER}-${JOB_NAME}
+  - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-02952e732e6126584
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
-    ssh_user: centos
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker
@@ -24,7 +24,7 @@ provisioner:
     converge: ../../playbooks/playbook.yml
 verifier:
   name: testinfra
-  directory: ../../../tests/tests_ppg
+  directory: ../../../tests/tests_meta_ha
   options:
     verbose: true
     s: true

--- a/ppg/pg-15-meta-server/molecule/ol-8/molecule.yml
+++ b/ppg/pg-15-meta-server/molecule/ol-8/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: ol8-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-065e2293a3df4c870
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-15-meta-server/molecule/ol-9/molecule.yml
+++ b/ppg/pg-15-meta-server/molecule/ol-9/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-02952e732e6126584
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-15-minor-upgrade/molecule/centos-7/molecule.yml
+++ b/ppg/pg-15-minor-upgrade/molecule/centos-7/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-04cf43aca3e6f3de3
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: centos
     root_device_name: /dev/sda1
     instance_tags:

--- a/ppg/pg-15-minor-upgrade/molecule/debian-10/molecule.yml
+++ b/ppg/pg-15-minor-upgrade/molecule/debian-10/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-0f41e297b3c53fab8
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda
     instance_tags:

--- a/ppg/pg-15-minor-upgrade/molecule/debian-11/molecule.yml
+++ b/ppg/pg-15-minor-upgrade/molecule/debian-11/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-007428d10865c9957
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda
     instance_tags:

--- a/ppg/pg-15-minor-upgrade/molecule/ol-8/molecule.yml
+++ b/ppg/pg-15-minor-upgrade/molecule/ol-8/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: ol8-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-065e2293a3df4c870
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+    cleanup: ../../playbooks/cleanup.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg/
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-15-minor-upgrade/molecule/ol-9/molecule.yml
+++ b/ppg/pg-15-minor-upgrade/molecule/ol-9/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-02952e732e6126584
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+    cleanup: ../../playbooks/cleanup.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg/
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-15-minor-upgrade/molecule/ubuntu-bionic/molecule.yml
+++ b/ppg/pg-15-minor-upgrade/molecule/ubuntu-bionic/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-0a8561d8c5a4f098a
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
     instance_tags:

--- a/ppg/pg-15-minor-upgrade/molecule/ubuntu-focal/molecule.yml
+++ b/ppg/pg-15-minor-upgrade/molecule/ubuntu-focal/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-0be656e75e69af1a9
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
+    instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
     instance_tags:

--- a/ppg/pg-15-minor-upgrade/playbooks/cleanup.yml
+++ b/ppg/pg-15-minor-upgrade/playbooks/cleanup.yml
@@ -33,7 +33,9 @@
       vars:
         packages:
           - percona-postgresql15
-          - percona-postgresql15
+          - percona-postgresql-client-common
+          - percona-postgresql-common
+          - percona-postgresql-server-dev-all
           - percona-postgresql15-contrib
           - percona-postgresql15-debuginfo
           - percona-postgresql15-devel

--- a/ppg/pg-15-minor-upgrade/tasks/main.yml
+++ b/ppg/pg-15-minor-upgrade/tasks/main.yml
@@ -2,6 +2,16 @@
 - name: Configure repository
   include_tasks: ../../../tasks/install_percona_release.yml
 
+- name: Setting facts so that they will be persisted in the fact cache
+  ansible.builtin.set_fact:
+    pg_version_to_install: "{{ lookup('env', 'FROM_VERSION') | replace('ppg-','') }}"
+
+- name: End play on oracle linux 9
+  meta: end_play
+  when: ansible_os_family == "RedHat" and
+   ansible_distribution_major_version == "9" and
+   pg_version_to_install | string is version('15.1', '<=', strict=True)
+
 - name: Setup initial (old) repository
   command: percona-release enable {{ pg_version }} {{ repo }}
   vars:
@@ -142,7 +152,8 @@
         - percona-postgresql15-pltcl-debuginfo
         - percona-postgresql15-plpython3-debuginfo
         - percona-postgresql15-server-debuginfo
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+  when: ansible_os_family == "RedHat" and
+      (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
 
 - name: Stop postgresql service for RHEL based
   service:

--- a/ppg/pg-15/molecule/ol-8/molecule.yml
+++ b/ppg/pg-15/molecule/ol-8/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: centos8-${BUILD_NUMBER}-${JOB_NAME}
+  - name: ol8-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.micro
-    ssh_user: centos
+    instance_type: t2.small
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker
@@ -20,15 +20,14 @@ provisioner:
     create: ../../../../playbooks/create.yml
     destroy: ../../../../playbooks/destroy.yml
     prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
     converge: ../../playbooks/playbook.yml
-    cleanup: ../../playbooks/cleanup.yml
 verifier:
   name: testinfra
-  directory: ../../../tests/tests_ppg/
+  directory: ../../../tests/tests_ppg
   options:
     verbose: true
     s: true
-    m: upgrade
     junitxml: report.xml
 scenario:
   destroy_sequence:

--- a/ppg/pg-15/molecule/ol-9/molecule.yml
+++ b/ppg/pg-15/molecule/ol-9/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: centos8-${BUILD_NUMBER}-${JOB_NAME}
+  - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-02952e732e6126584
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
-    ssh_user: centos
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker
@@ -24,7 +24,7 @@ provisioner:
     converge: ../../playbooks/playbook.yml
 verifier:
   name: testinfra
-  directory: ../../../tests/tests_meta_server
+  directory: ../../../tests/tests_ppg
   options:
     verbose: true
     s: true

--- a/ppg/tests/settings.py
+++ b/ppg/tests/settings.py
@@ -53,7 +53,7 @@ def get_settings(distro_type):
             "extensions": ppg_versions["ppg-11.19"]["extensions"],
             "languages": ppg_versions["ppg-11.19"]["languages"],
             "binaries": ppg_versions["ppg-11.19"]["binaries"],
-            "pg_stat_monitor": "2.0.0",
+            "pg_stat_monitor": "2.0.1",
         },
         "ppg-11.18": {
             "version": "11.18",
@@ -803,7 +803,7 @@ def get_settings(distro_type):
             "extensions": ppg_versions["ppg-12.14"]["extensions"],
             "languages": ppg_versions["ppg-12.14"]["languages"],
             "binaries": ppg_versions["ppg-12.14"]["binaries"],
-            "pg_stat_monitor": "2.0.0"
+            "pg_stat_monitor": "2.0.1"
         },
         "ppg-13.0": {
              "version": "13.0",
@@ -1128,7 +1128,7 @@ def get_settings(distro_type):
             "extensions": ppg_versions["ppg-13.10"]["extensions"],
             "languages": ppg_versions["ppg-13.10"]["languages"],
             "binaries": ppg_versions["ppg-13.10"]["binaries"],
-            "pg_stat_monitor": "2.0.0"
+            "pg_stat_monitor": "2.0.1"
         },
         "ppg-14.0": {
             "version": "14.0",
@@ -1374,7 +1374,7 @@ def get_settings(distro_type):
             "extensions": ppg_versions["ppg-14.7"]["extensions"],
             "languages": ppg_versions["ppg-14.7"]["languages"],
             "binaries": ppg_versions["ppg-14.7"]["binaries"],
-            "pg_stat_monitor": "2.0.0"
+            "pg_stat_monitor": "2.0.1"
         },
         "ppg-15.0": {
             "version": "15.0",
@@ -1468,6 +1468,6 @@ def get_settings(distro_type):
             "extensions": ppg_versions["ppg-15.2"]["extensions"],
             "languages": ppg_versions["ppg-15.2"]["languages"],
             "binaries": ppg_versions["ppg-15.2"]["binaries"],
-            "pg_stat_monitor": "2.0.0"
+            "pg_stat_monitor": "2.0.1"
         },
     }

--- a/ppg/tests/tests_meta_ha/test_meta_ha.py
+++ b/ppg/tests/tests_meta_ha/test_meta_ha.py
@@ -14,7 +14,7 @@ DEB_PACKAGES = ['percona-patroni', 'etcd', 'percona-haproxy', 'etcd-client', 'et
 @pytest.mark.parametrize("package", DEB_PACKAGES)
 def test_deb_package_is_installed(host, package):
     ds = host.system_info.distribution
-    if ds.lower() in ["redhat", "centos", 'rhel']:
+    if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
         pytest.skip("This test only for Debian based platforms")
     pkg = host.package(package)
     assert pkg.is_installed

--- a/ppg/tests/tests_meta_server/test_meta_server.py
+++ b/ppg/tests/tests_meta_server/test_meta_server.py
@@ -23,7 +23,7 @@ DEB_PACKAGES = [
 @pytest.mark.parametrize("package", DEB_PACKAGES)
 def test_deb_package_is_installed(host, package):
     ds = host.system_info.distribution
-    if ds.lower() in ["redhat", "centos", 'rhel']:
+    if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
         pytest.skip("This test only for Debian based platforms")
     pkg = host.package(package)
     assert pkg.is_installed

--- a/ppg/tests/tests_ppg/test_bvt.py
+++ b/ppg/tests/tests_ppg/test_bvt.py
@@ -44,7 +44,7 @@ def start_stop_postgresql(host):
 def postgresql_binary(host):
     dist = host.system_info.distribution
     pg_bin = f"/usr/lib/postgresql/{settings.MAJOR_VER}/bin/postgres"
-    if dist.lower() in ["redhat", "centos", 'rhel']:
+    if dist.lower() in ["redhat", "centos", "rhel", "ol"]:
         pg_bin = f"/usr/pgsql-{settings.MAJOR_VER}/bin/postgres"
     return host.file(pg_bin)
 
@@ -77,7 +77,7 @@ def insert_data(host):
     ds = host.system_info.distribution
     print(host.run("find / -name pgbench").stdout)
     pgbench_bin = "pgbench"
-    if ds.lower() in ["redhat", "centos", 'rhel']:
+    if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
         pgbench_bin = f"/usr/pgsql-{pg_versions['version'].split('.')[0]}/bin/pgbench"
     with host.sudo("postgres"):
         pgbench = f"{pgbench_bin} -i -s 1"
@@ -97,7 +97,7 @@ def test_psql_client_version(host):
 @pytest.mark.parametrize("package", pg_versions['deb_packages'])
 def test_deb_package_is_installed(host, package):
     ds = host.system_info.distribution
-    if ds.lower() in ["redhat", "centos", 'rhel']:
+    if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
         pytest.skip("This test only for Debian based platforms")
     pkg = host.package(package)
     assert pkg.is_installed
@@ -142,7 +142,7 @@ def test_rpm7_package_is_installed(host, package):
 def test_postgresql_client_version(host):
     ds = host.system_info.distribution
     pkg = "percona-postgresql-{}".format(settings.MAJOR_VER)
-    if ds.lower() in ["redhat", "centos", 'rhel']:
+    if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
         pytest.skip("This test only for Debian based platforms")
     pkg = host.package(pkg)
     assert settings.MAJOR_VER in pkg.version
@@ -152,7 +152,7 @@ def test_postgresql_client_version(host):
 def test_postgresql_version(host):
     ds = host.system_info.distribution
     pkg = "percona-postgresql-client-{}".format(settings.MAJOR_VER)
-    if ds.lower() in ["redhat", "centos", 'rhel']:
+    if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
         pkg = "percona-postgresql{}".format(settings.MAJOR_VER)
     pkg = host.package(pkg)
     assert settings.MAJOR_VER in pkg.version, pkg.version
@@ -162,7 +162,7 @@ def test_postgresql_version(host):
 def test_postgresql_is_running_and_enabled(host):
     ds = host.system_info.distribution
     service_name = "postgresql"
-    if ds.lower() in ["redhat", "centos", 'rhel']:
+    if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
         service_name = f"postgresql-{settings.MAJOR_VER}"
     service = host.service(service_name)
     assert service.is_running
@@ -182,7 +182,7 @@ def test_postgres_binary(postgresql_binary):
 def test_binaries(host, binary):
     dist = host.system_info.distribution
     bin_path = f"/usr/lib/postgresql/{settings.MAJOR_VER}/bin/"
-    if dist.lower() in ["redhat", "centos", 'rhel']:
+    if dist.lower() in ["redhat", "centos", "rhel", "ol"]:
         bin_path = f"/usr/pgsql-{settings.MAJOR_VER}/bin/"
     bin_full_path = os.path.join(bin_path, binary)
     binary_file = host.file(bin_full_path)
@@ -230,7 +230,7 @@ def test_insert_data(insert_data):
 def test_extenstions_list(extension_list, host):
     ds = host.system_info.distribution
     for extension in EXTENSIONS:
-        if ds.lower() in ['centos', 'redhat', 'rhel']:
+        if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
             if "python3" in extension:
                 pytest.skip("Skipping python3 extensions for Centos or RHEL")
             if extension in [
@@ -247,7 +247,7 @@ def test_extenstions_list(extension_list, host):
 @pytest.mark.parametrize("extension", EXTENSIONS)
 def test_enable_extension(host, extension):
     ds = host.system_info.distribution
-    if ds.lower() in ["redhat", "centos", 'rhel']:
+    if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
         if "python3" in extension:
             pytest.skip("Skipping python3 extensions for Centos or RHEL")
         if extension in [
@@ -272,7 +272,7 @@ def test_enable_extension(host, extension):
 @pytest.mark.parametrize("extension", EXTENSIONS[::-1])
 def test_drop_extension(host, extension):
     ds = host.system_info.distribution
-    if ds.lower() in ["redhat", "centos", 'rhel']:
+    if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
         if "python3" in extension:
             pytest.skip("Skipping python3 extensions for Centos or RHEL")
         if extension in [
@@ -308,7 +308,7 @@ def test_plpgsql_extension(host):
 @pytest.mark.parametrize("file", DEB_FILES)
 def test_deb_files(host, file):
     os = host.system_info.distribution
-    if os.lower() in ["redhat", "centos", 'rhel']:
+    if os.lower() in ["redhat", "centos", "rhel", "ol"]:
         pytest.skip("This test only for Debian based platforms")
     with host.sudo("postgres"):
         f = host.file(file)
@@ -336,7 +336,7 @@ def test_language(host, language):
     dists = ['debian', 'ubuntu']
     ds = host.system_info.distribution
     with host.sudo("postgres"):
-        if ds.lower() in ["redhat", "centos", 'rhel']:
+        if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
             if "python3" in language:
                 pytest.skip("Skipping python3 language for Centos or RHEL")
         if ds.lower() in dists and language in ['plpythonu', "plpython2u"] or settings.MAJOR_VER in ["13", "14", "15"]:
@@ -354,7 +354,7 @@ def test_deb_packages_provides(host, percona_package, vanila_package):
     """Execute command for check provides and check that we have link to vanila postgres
     """
     os = host.system_info.distribution
-    if os.lower() in ["redhat", "centos", 'rhel']:
+    if os.lower() in ["redhat", "centos", "rhel", "ol"]:
         pytest.skip("This test only for Debs.ian based platforms")
     cmd = "dpkg -s {} | grep Provides".format(percona_package)
     result = host.run(cmd)

--- a/ppg/tests/tests_ppg/test_components.py
+++ b/ppg/tests/tests_ppg/test_components.py
@@ -33,7 +33,7 @@ $$ LANGUAGE plperl;
 @pytest.fixture()
 def python3_function(host):
     os = host.system_info.distribution
-    if os.lower() in ['centos', 'redhat', 'rhel']:
+    if os.lower() in ["redhat", "centos", "rhel", "ol"]:
         pytest.skip("Skipping python3 extensions for Centos or RHEL")
     with host.sudo("postgres"):
         install_extension = host.run("psql -c 'CREATE EXTENSION IF NOT EXISTS \"plpython3u\";'")
@@ -75,7 +75,7 @@ def build_libpq_programm(host):
     pg_include = host.check_output(pg_include_cmd)
     lib_dir_cmd = "pg_config --libdir"
     host.check_output(lib_dir_cmd)
-    if os in ["centos", 'rhel', "redhat"]:
+    if os in ["redhat", "centos", "rhel", "ol"]:
         return host.run(
             "export LIBPQ_DIR=/usr/pgsql-{}/  && export LIBRARY_PATH=/usr/pgsql-{}/lib/ &&"
             "gcc -o lib_version /tmp/libpq_command_temp_dir/lib_version.c -I{} -lpq -std=c99".format(
@@ -87,7 +87,7 @@ def build_libpq_programm(host):
 @pytest.mark.parametrize("package", PACKAGES)
 def test_deb_package_is_installed(host, package):
     os = host.system_info.distribution
-    if os.lower() in ["redhat", "centos", 'rhel']:
+    if os.lower() in ["redhat", "centos", "rhel", "ol"]:
         pytest.skip("This test only for Debian based platforms")
     pkg = host.package(package)
     assert pkg.is_installed

--- a/ppg/tests/tests_ppg/test_tools.py
+++ b/ppg/tests/tests_ppg/test_tools.py
@@ -55,7 +55,7 @@ def pgaudit(host):
         log_file = "/var/log/postgresql/postgresql-{}-main.log".format(settings.MAJOR_VER)
         if ds.lower() in ["debian", "ubuntu"]:
             log_file = "/var/log/postgresql/postgresql-{}-main.log".format(settings.MAJOR_VER)
-        elif ds.lower() in ["redhat", "centos", 'rhel']:
+        elif ds.lower() in ["redhat", "centos", "ol", "rhel"]:
             log_files = "ls /var/lib/pgsql/{}/data/log/".format(settings.MAJOR_VER)
             file_name = host.check_output(log_files).strip("\n")
             log_file = "".join(["/var/lib/pgsql/{}/data/log/".format(settings.MAJOR_VER), file_name])
@@ -68,7 +68,7 @@ def pgaudit(host):
         assert result.strip("\n") == "DROP EXTENSION"
     if ds.lower() in ["debian", "ubuntu"]:
         cmd = "sudo systemctl restart postgresql"
-    elif ds.lower() in ["redhat", "centos", 'rhel']:
+    elif ds.lower() in ["redhat", "centos", "ol", "rhel"]:
         cmd = "sudo systemctl restart postgresql-{}".format(MAJOR_VER)
     result = host.run(cmd)
     assert result.rc == 0
@@ -132,7 +132,7 @@ def pgbackrest_delete_data(host):
     dist = host.system_info.distribution
     data_dir = f"/var/lib/postgresql/{MAJOR_VER}/main/*"
     service_name = "postgresql"
-    if dist.lower() in ["redhat", "centos", 'rhel']:
+    if dist.lower() in ["redhat", "centos", "ol", "rhel"]:
         data_dir = f"/var/lib/pgsql/{MAJOR_VER}/data/*"
         service_name = f"postgresql-{MAJOR_VER}"
     with host.sudo("root"):
@@ -158,7 +158,7 @@ def pgbackrest_restore(pgbackrest_delete_data, host):
 def pgrepack(host):
     dist = host.system_info.distribution
     cmd = f"/usr/lib/postgresql/{MAJOR_VER}/bin/pg_repack"
-    if dist.lower() in ["redhat", "centos", 'rhel']:
+    if dist.lower() in ["redhat", "centos", "ol", "rhel"]:
         cmd = f"/usr/pgsql-{MAJOR_VER}/bin/pg_repack "
     return host.check_output(cmd)
 
@@ -168,7 +168,7 @@ def pg_repack_functional(host):
     dist = host.system_info.distribution
     pgbench_bin = "pgbench"
     pg_repack_bin = f"/usr/lib/postgresql/{MAJOR_VER}/bin/pg_repack"
-    if dist.lower() in ["redhat", "centos", 'rhel']:
+    if dist.lower() in ["redhat", "centos", "ol", "rhel"]:
         pgbench_bin = f"/usr/pgsql-{pg_versions['version'].split('.')[0]}/bin/pgbench"
         pg_repack_bin = f"/usr/pgsql-{MAJOR_VER}/bin/pg_repack"
     with host.sudo("postgres"):
@@ -177,7 +177,7 @@ def pg_repack_functional(host):
         select = "psql -c 'SELECT COUNT(*) FROM pgbench_accounts;' | awk 'NR==3{print $3}'"
         assert host.run(select).rc == 0
         cmd = f"{pg_repack_bin} -t pgbench_accounts -j 4"
-        if dist.lower() in ["redhat", "centos", 'rhel']:
+        if dist.lower() in ["redhat", "centos", "ol", "rhel"]:
             cmd = f"{pg_repack_bin} -t pgbench_accounts -j 4"
         pg_repack_result = host.run(cmd)
     yield pg_repack_result
@@ -188,7 +188,7 @@ def pg_repack_dry_run(host, operating_system):
     dist = host.system_info.distribution
     pgbench_bin = "pgbench"
     pg_repack_bin = f"/usr/lib/postgresql/{MAJOR_VER}/bin/pg_repack"
-    if dist.lower() in ["redhat", "centos", 'rhel']:
+    if dist.lower() in ["redhat", "centos", "ol", "rhel"]:
         pgbench_bin = f"/usr/pgsql-{pg_versions['version'].split('.')[0]}/bin/pgbench"
         pg_repack_bin = f"/usr/pgsql-{MAJOR_VER}/bin/pg_repack"
     with host.sudo("postgres"):
@@ -197,7 +197,7 @@ def pg_repack_dry_run(host, operating_system):
         select = "psql -c 'SELECT COUNT(*) FROM pgbench_accounts;' | awk 'NR==3{print $3}'"
         assert host.run(select).rc == 0
         cmd = f"{pg_repack_bin} --dry-run -d postgres"
-        if operating_system.lower() in ["redhat", "centos", 'rhel']:
+        if operating_system.lower() in ["redhat", "centos", "ol", "rhel"]:
             cmd = f"{pg_repack_bin} --dry-run -d postgres"
 
         pg_repack_result = host.run(cmd)
@@ -208,7 +208,7 @@ def pg_repack_dry_run(host, operating_system):
 def pg_repack_client_version(host, operating_system):
     with host.sudo("postgres"):
         cmd = f"/usr/lib/postgresql/{MAJOR_VER}/bin/pg_repack --version"
-        if operating_system.lower() in ["redhat", "centos", 'rhel']:
+        if operating_system.lower() in ["redhat", "centos", "ol", "rhel"]:
             cmd = f"/usr/pgsql-{MAJOR_VER}/bin/pg_repack --version"
         return host.run(cmd)
 
@@ -228,7 +228,7 @@ def test_pgaudit_package(host):
     with host.sudo():
         os = host.system_info.distribution
         pkgn = ""
-        if os.lower() in ["redhat", "centos", 'rhel']:
+        if os.lower() in ["redhat", "centos", "ol", "rhel"]:
             pkgn = "percona-pgaudit"
             # pkgn = "percona-pgaudit14_12"
         elif os in ["debian", "ubuntu"]:
@@ -254,7 +254,7 @@ def test_pgrepack_package(host):
 
         os = host.system_info.distribution
         pkgn = ""
-        if os.lower() in ["redhat", "centos", 'rhel']:
+        if os.lower() in ["redhat", "centos", "ol", "rhel"]:
             pkgn = pg_versions['pgrepack_package_rpm']
         elif os in ["debian", "ubuntu"]:
             pkgn = pg_versions['pgrepack_package_deb']
@@ -308,7 +308,7 @@ def test_pgbackrest_package(host):
     with host.sudo():
         os = host.system_info.distribution
         pkgn = ""
-        if os.lower() in ["redhat", "centos", 'rhel']:
+        if os.lower() in ["redhat", "centos", "ol", "rhel"]:
             pkgn = "percona-pgbackrest"
         elif os in ["debian", "ubuntu"]:
             pkgn = "percona-pgbackrest"
@@ -345,7 +345,7 @@ def test_pgbackrest_full_backup(pgbackrest_full_backup):
 
 def test_pgbackrest_restore(host):
     os = host.system_info.distribution
-    if os.lower() in ["redhat", "centos", 'rhel']:
+    if os.lower() in ["redhat", "centos", "ol", "rhel"]:
         service_name = "postgresql-{}".format(MAJOR_VER)
     else:
         service_name = "postgresql"
@@ -364,7 +364,7 @@ def test_patroni_package(host):
 
         os = host.system_info.distribution
         pkgn = ""
-        if os.lower() in ["ubuntu", "redhat", "centos", 'rhel']:
+        if os.lower() in ["ubuntu", "redhat", "centos", "ol", "rhel"]:
             pkgn = "percona-patroni"
         elif os == "debian":
             pkgn = "percona-patroni"
@@ -431,7 +431,7 @@ def test_binary_version(host, binary):
 
 def test_etcd(host):
     ds = host.system_info.distribution
-    if ds.lower() in ["redhat", "centos", 'rhel']:
+    if ds.lower() in ["redhat", "centos", "ol", "rhel"]:
         if "8" in host.system_info.release:
             etcd_package = host.package("etcd")
             assert etcd_package.is_installed
@@ -442,7 +442,7 @@ def test_etcd(host):
 
 def test_python_etcd(host):
     ds = host.system_info.distribution
-    if ds.lower() in ["redhat", "centos", 'rhel']:
+    if ds.lower() in ["redhat", "centos", "ol", "rhel"]:
         if "8" in host.system_info.release:
             package = host.package("python3-etcd")
             assert package.is_installed
@@ -474,7 +474,7 @@ def test_pgpool_package_version(host):
 
 def test_pgpool_binary_version(host):
     dist = host.system_info.distribution
-    if dist.lower() in ["redhat", "centos", 'rhel','ubuntu']:
+    if dist.lower() in ["redhat", "centos", "ol", "rhel",'ubuntu']:
         result = host.run(f"pgpool --version 2>&1 | grep pgpool | cut -d' ' -f3")
         assert result.rc == 0, result.stderr
         assert pg_versions["pgpool"]['binary_version'] in result.stdout.strip("\n"), result.stdout

--- a/tasks/install_pg15.yml
+++ b/tasks/install_pg15.yml
@@ -26,9 +26,20 @@
     command: sudo dnf module disable postgresql -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
+  - name: Enable ol8_codeready_builder on oracle linux 8
+    become: true
+    command: dnf config-manager --set-enabled ol8_codeready_builder
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+
+  - name: Enable ol9_codeready_builder on oracle linux 9
+    become: true
+    command: dnf config-manager --set-enabled ol9_codeready_builder
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
   - name: DNF clean RHEL
     command: sudo dnf clean all -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+    when: ansible_os_family == "RedHat" and
+      (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
 
   - name: Add PostgreSQL YUM Repository RHEL7
     yum: name=https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm state=present validate_certs=false
@@ -37,6 +48,10 @@
   - name: Add PostgreSQL YUM Repository RHEL8
     yum: name=https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm state=present validate_certs=false
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+
+  - name: Add PostgreSQL YUM Repository RHEL8
+    yum: name=https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm state=present validate_certs=false
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
 
   - name: Install vanila postgres RHEL
     yum:

--- a/tasks/install_ppg14.yml
+++ b/tasks/install_ppg14.yml
@@ -10,37 +10,21 @@
     command: dnf clean all -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-  - name: Enable powertools RHEL8
+  - name: Clean dnf oracle linux
     become: true
-    command: dnf config-manager --set-enabled powertools
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+    command: dnf clean all -y
+    when: ansible_os_family == "RedHat" and
+      (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
 
-  - name: Find all of the files inside /etc/yum.repos.d directory
-    find:
-      paths: "/etc/yum.repos.d/"
-      patterns: "*.repo"
-    register: repos
-
-  - name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: 'mirrorlist'
-      replace: '#mirrorlist'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: '#baseurl=http://mirror.centos.org'
-      replace: 'baseurl=http://vault.centos.org'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Update dnf RHEL8
+  - name: Enable powertools on oracle linux 8
     become: true
-    command: dnf update -y
+    command: dnf config-manager --set-enabled ol8_codeready_builder
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+
+  - name: Enable powertools on oracle linux 9
+    become: true
+    command: dnf config-manager --set-enabled ol9_codeready_builder
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
 
   - name: Disable dnf module for RHEL8
     become: true
@@ -79,18 +63,6 @@
       - percona-postgresql-plpython3-14-dbgsym
       - percona-postgresql-pltcl-14-dbgsym
     when: ansible_os_family == "Debian"
-
-  - name: install Percona Platform for PostgreSQL deb packages
-    apt:
-      name: "{{ packages }}"
-      update_cache: yes
-      state: latest
-    vars:
-      packages:
-      - percona-postgresql-plpython3-14
-      - percona-postgresql-plpython3-14-dbgsym
-    when:
-      - ansible_os_family == "Debian"
 
   - name: install Percona Platform for PostgreSQL rpm packages for RHEL
     yum:
@@ -149,4 +121,5 @@
         - percona-postgresql14-plpython3-debuginfo
         - percona-postgresql14-server-debuginfo
         - percona-postgresql14-test-debuginfo
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+    when: ansible_os_family == "RedHat" and
+      (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")

--- a/tasks/install_ppg14_tools.yml
+++ b/tasks/install_ppg14_tools.yml
@@ -166,6 +166,13 @@
       update_cache: yes
     when: ansible_os_family == "RedHat"
 
+  - name: Install python3-pip
+    yum:
+      name: python3-pip
+      state: latest
+      update_cache: yes
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
   - name: Install python3 module - patroni[etcd]
     become: true
     command: python3 -m pip install patroni[etcd]
@@ -218,6 +225,27 @@
       update_cache: yes
     when: ansible_os_family == "Debian"
 
+  - name: Install CPAN
+    become: true
+    command: yum -y install perl-CPAN
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
+  - name: Install perl-App-cpanminus
+    become: true
+    command: yum -y install perl-App-cpanminus
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
+  - name: Install perl module Benchmark
+    become: true
+    command: cpanm Benchmark
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
   - name: Install percona-pgaudit14_set_user RHEL
     yum:
       name: percona-pgaudit14_set_user
@@ -263,7 +291,8 @@
       packages:
         - percona-pgpool-II-pg14
         - percona-pgpool-II-pg14-extensions
-    when: ansible_os_family == "RedHat"
+    when: (ansible_os_family == "RedHat" and pg_version_to_install is not defined) or
+      (ansible_os_family == "RedHat" and pg_version_to_install | string is version('14.7', '>=', strict=True))
 
   - name: Install percona-pgpool Debian
     apt:
@@ -274,7 +303,8 @@
       packages:
         - percona-pgpool2
         - libpgpool2
-    when: ansible_os_family == "Debian"
+    when: (ansible_os_family == "Debian" and pg_version_to_install is not defined) or
+      (ansible_os_family == "Debian" and pg_version_to_install | string is version('14.7', '>=', strict=True))
 
   - name: Install percona-wal2json14 RHEL
     yum:
@@ -564,14 +594,16 @@
       name: pgpool
       state: started
       enabled: yes
-    when: ansible_os_family == "RedHat"
+    when: (ansible_os_family == "RedHat" and pg_version_to_install is not defined) or
+      (ansible_os_family == "RedHat" and pg_version_to_install | string is version('14.7', '>=', strict=True))
 
   - name: Start pgpool service
     service:
       name: percona-pgpool2
       state: started
       enabled: yes
-    when: ansible_os_family == "Debian"
+    when: (ansible_os_family == "Debian" and pg_version_to_install is not defined) or
+      (ansible_os_family == "Debian" and pg_version_to_install | string is version('14.7', '>=', strict=True))
 
   - name: Add user postgres to sudoers
     user:

--- a/tasks/install_ppg15.yml
+++ b/tasks/install_ppg15.yml
@@ -5,42 +5,21 @@
       state: present
     when: ansible_os_family == "RedHat"
 
-  - name: Clean dnf RHEL8
+  - name: Clean dnf oracle linux
     become: true
     command: dnf clean all -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+    when: ansible_os_family == "RedHat" and
+      (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
 
-  - name: Enable powertools RHEL8
+  - name: Enable powertools on oracle linux 8
     become: true
-    command: dnf config-manager --set-enabled powertools
+    command: dnf config-manager --set-enabled ol8_codeready_builder
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-  - name: Find all of the files inside /etc/yum.repos.d directory
-    find:
-      paths: "/etc/yum.repos.d/"
-      patterns: "*.repo"
-    register: repos
-
-  - name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: 'mirrorlist'
-      replace: '#mirrorlist'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: '#baseurl=http://mirror.centos.org'
-      replace: 'baseurl=http://vault.centos.org'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Update dnf RHEL8
+  - name: Enable powertools on oracle linux 9
     become: true
-    command: dnf update -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+    command: dnf config-manager --set-enabled ol9_codeready_builder
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
 
   - name: Disable dnf postgresql for RHEL8
     become: true
@@ -148,4 +127,5 @@
         - percona-postgresql15-pltcl-debuginfo
         - percona-postgresql15-plpython3-debuginfo
         - percona-postgresql15-server-debuginfo
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+    when: ansible_os_family == "RedHat" and
+      (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")

--- a/tasks/install_ppg15_tools.yml
+++ b/tasks/install_ppg15_tools.yml
@@ -154,6 +154,13 @@
       update_cache: yes
     when: ansible_os_family == "RedHat"
 
+  - name: Install python3-pip
+    yum:
+      name: python3-pip
+      state: latest
+      update_cache: yes
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
   - name: Install python3 module - patroni[etcd]
     become: true
     command: python3 -m pip install patroni[etcd]
@@ -206,6 +213,27 @@
       update_cache: yes
     when: ansible_os_family == "Debian"
 
+  - name: Install CPAN
+    become: true
+    command: yum -y install perl-CPAN
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
+  - name: Install perl-App-cpanminus
+    become: true
+    command: yum -y install perl-App-cpanminus
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
+  - name: Install perl module Benchmark
+    become: true
+    command: cpanm Benchmark
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
   - name: Install percona-pgaudit15_set_user RHEL
     yum:
       name: percona-pgaudit15_set_user
@@ -251,7 +279,8 @@
       packages:
         - percona-pgpool-II-pg15
         - percona-pgpool-II-pg15-extensions
-    when: ansible_os_family == "RedHat"
+    when: (ansible_os_family == "RedHat" and pg_version_to_install is not defined) or
+      (ansible_os_family == "RedHat" and pg_version_to_install | string is version('15.2', '>=', strict=True))
 
   - name: Install percona-pgpool Debian
     apt:
@@ -262,7 +291,8 @@
       packages:
         - percona-pgpool2
         - libpgpool2
-    when: ansible_os_family == "Debian"
+    when: (ansible_os_family == "Debian" and pg_version_to_install is not defined) or
+      (ansible_os_family == "Debian" and pg_version_to_install | string is version('15.2', '>=', strict=True))
 
   - name: Install percona-wal2json15 RHEL
     yum:
@@ -552,14 +582,16 @@
       name: pgpool
       state: started
       enabled: yes
-    when: ansible_os_family == "RedHat"
+    when: (ansible_os_family == "RedHat" and pg_version_to_install is not defined) or
+      (ansible_os_family == "RedHat" and pg_version_to_install | string is version('15.2', '>=', strict=True))
 
   - name: Start pgpool service
     service:
       name: percona-pgpool2
       state: started
       enabled: yes
-    when: ansible_os_family == "Debian"
+    when: (ansible_os_family == "Debian" and pg_version_to_install is not defined) or
+      (ansible_os_family == "Debian" and pg_version_to_install | string is version('15.2', '>=', strict=True))
 
   - name: Add user postgres to sudoers
     user:

--- a/tasks/install_ppg_meta_ha.yml
+++ b/tasks/install_ppg_meta_ha.yml
@@ -7,37 +7,15 @@
     command: dnf clean all -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-  - name: Find all of the files inside /etc/yum.repos.d directory
-    find:
-      paths: "/etc/yum.repos.d/"
-      patterns: "*.repo"
-    register: repos
-
-  - name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: 'mirrorlist'
-      replace: '#mirrorlist'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: '#baseurl=http://mirror.centos.org'
-      replace: 'baseurl=http://vault.centos.org'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Update dnf RHEL8
+  - name: Enable powertools on oracle linux 8
     become: true
-    command: dnf update -y
+    command: dnf config-manager --set-enabled ol8_codeready_builder
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-  - name: Enable powertools RHEL8
+  - name: Enable powertools on oracle linux 9
     become: true
-    command: dnf config-manager --set-enabled powertools
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+    command: dnf config-manager --set-enabled ol9_codeready_builder
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
 
   - name: Disable dnf module for RHEL8
     become: true
@@ -62,6 +40,13 @@
       state: latest
       update_cache: yes
     when: ansible_os_family == "RedHat"
+
+  - name: Install python3-pip
+    yum:
+      name: python3-pip
+      state: latest
+      update_cache: yes
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
 
   - name: Install python3 module - patroni[etcd]
     become: true

--- a/tasks/install_ppg_meta_server.yml
+++ b/tasks/install_ppg_meta_server.yml
@@ -7,37 +7,15 @@
     command: dnf clean all -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-  - name: Find all of the files inside /etc/yum.repos.d directory
-    find:
-      paths: "/etc/yum.repos.d/"
-      patterns: "*.repo"
-    register: repos
-
-  - name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: 'mirrorlist'
-      replace: '#mirrorlist'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: '#baseurl=http://mirror.centos.org'
-      replace: 'baseurl=http://vault.centos.org'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Update dnf RHEL8
+  - name: Enable powertools on oracle linux 8
     become: true
-    command: dnf update -y
+    command: dnf config-manager --set-enabled ol8_codeready_builder
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-  - name: Enable powertools RHEL8
+  - name: Enable powertools on oracle linux 9
     become: true
-    command: dnf config-manager --set-enabled powertools
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+    command: dnf config-manager --set-enabled ol9_codeready_builder
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
 
   - name: Disable dnf module for RHEL8
     become: true


### PR DESCRIPTION
1. Integrated oracle linux (OL) 8 image instead of centos8.
2. Integrated OL-9 image into workflows.
3. Updating patroni and pg_stat_monitor testing from centos8 to ol8.
4. Install perl module Benchmark needed on ol-9 to check pgbadger.
5. Install pip on ol-9.
6. Fixed pgsm regression dependencies on ppg 11~15.
7. Added ol-8 and ol-9 for ha and meta-server. Updated the ha and meta-server scripts to accommodate ol-8 and ol-9.
8. Added conditional install of pgpool based on ppg version >= 15.2.
9. Added ol-8 & ol-9 to ppg15 minor upgrade.
10. Done minor update after using t2.small instead of t2.micro.
11. Changes to accommodate the pg-14-major upgrade.
12. Changes for pg-15-components-with-vanilla.
13. Fixed pgBouncer regression failure on pg-15.
14. Fixed pgBackrest regression failure on pg-15.
15. Changes for PGSM 2.0.1 release.