### PR TITLE
ppg-12 changes in this commit are following:

### DIFF
--- a/ppg/pg-12/molecule/ol-8/molecule.yml
+++ b/ppg/pg-12/molecule/ol-8/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: ol8-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-065e2293a3df4c870
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-12/molecule/ol-9/molecule.yml
+++ b/ppg/pg-12/molecule/ol-9/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: centos8-${BUILD_NUMBER}-${JOB_NAME}
+  - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-02952e732e6126584
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
-    ssh_user: centos
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker

--- a/ppg/tests/tests_ppg/test_bvt.py
+++ b/ppg/tests/tests_ppg/test_bvt.py
@@ -113,6 +113,10 @@ def test_rpm_package_is_installed(host, package):
             pytest.skip("This test only for RHEL based platforms")
         if host.system_info.release == "7":
             pytest.skip("Only for RHEL8 tests")
+        if package in [
+                'percona-postgresql12-plpython', "percona-postgresql12-plpython-debuginfo"] and \
+                settings.MAJOR_VER in ["12"] and host.system_info.release.startswith("9"):
+            pytest.skip("Skipping for OL 9 based ppg 12")
         pkg = host.package(package)
         assert pkg.is_installed
         if package not in ["percona-postgresql-client-common", "percona-postgresql-common"]:
@@ -128,7 +132,7 @@ def test_rpm7_package_is_installed(host, package):
         ds = host.system_info.distribution
         if ds in ["debian", "ubuntu"]:
             pytest.skip("This test only for RHEL based platforms")
-        if host.system_info.release == "8.0":
+        if host.system_info.release.startswith("8") or host.system_info.release.startswith("9"):
             pytest.skip("Only for centos7 tests")
         pkg = host.package(package)
         assert pkg.is_installed
@@ -237,6 +241,10 @@ def test_extenstions_list(extension_list, host):
                 'plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
                 'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u'] and settings.MAJOR_VER in ["13", "14", "15"]:
                 pytest.skip("Skipping extensions for Centos or RHEL")
+            if extension in [
+                'plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
+                'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u'] and settings.MAJOR_VER in ["12"] and host.system_info.release.startswith("9"):
+                pytest.skip("Skipping python2 extensions for OL 9 based ppg 12")
         if ds.lower() in ['debian', 'ubuntu'] and os.getenv("VERSION") in SKIPPED_DEBIAN:
             if extension in ['plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
                              'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u']:
@@ -254,6 +262,11 @@ def test_enable_extension(host, extension):
             'plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
             'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u'] and settings.MAJOR_VER in ["13", "14", "15"]:
             pytest.skip("Skipping extensions for Centos or RHEL")
+        if extension in [
+            'plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
+            'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u'] and settings.MAJOR_VER in ["12"] and host.system_info.release.startswith("9"):
+            pytest.skip("Skipping python2 extensions for OL 9 based ppg 12")
+
     if ds.lower() in ['debian', 'ubuntu'] and os.getenv("VERSION") in SKIPPED_DEBIAN:
         if extension in ['plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
                          'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u']:
@@ -279,6 +292,10 @@ def test_drop_extension(host, extension):
             'plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
             'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u'] and settings.MAJOR_VER in ["13", "14", "15"]:
             pytest.skip("Skipping extensions for Centos or RHEL")
+        if extension in [
+            'plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
+            'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u'] and settings.MAJOR_VER in ["12"] and host.system_info.release.startswith("9"):
+            pytest.skip("Skipping python2 extensions for OL 9 based ppg 12")
 
     if ds.lower() in ['debian', 'ubuntu'] and os.getenv("VERSION") in SKIPPED_DEBIAN:
         if extension in ['plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
@@ -341,6 +358,8 @@ def test_language(host, language):
                 pytest.skip("Skipping python3 language for Centos or RHEL")
         if ds.lower() in dists and language in ['plpythonu', "plpython2u"] or settings.MAJOR_VER in ["13", "14", "15"]:
             pytest.skip("Skipping python2 extensions for DEB based in 12.* and all centos 13")
+        if language in ['plpythonu', "plpython2u"] and settings.MAJOR_VER in ["12"] and host.system_info.release.startswith("9"):
+            pytest.skip("Skipping python2 extensions for OL 9 based ppg 12")
         lang = host.run("psql -c 'CREATE LANGUAGE {};'".format(language))
         assert lang.rc == 0, lang.stderr
         assert lang.stdout.strip("\n") in ["CREATE LANGUAGE", "CREATE EXTENSION"], lang.stdout

--- a/tasks/install_ppg12.yml
+++ b/tasks/install_ppg12.yml
@@ -5,49 +5,28 @@
       state: present
     when: ansible_os_family == "RedHat"
 
-  - name: Clean dnf RHEL8
+  - name: Clean dnf oracle linux
     become: true
     command: dnf clean all -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+    when: ansible_os_family == "RedHat" and
+      (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
 
-  - name: Enable powertools RHEL8
+  - name: Enable powertools on oracle linux 8
     become: true
-    command: dnf config-manager --set-enabled powertools
+    command: dnf config-manager --set-enabled ol8_codeready_builder
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-  - name: Find all of the files inside /etc/yum.repos.d directory
-    find:
-      paths: "/etc/yum.repos.d/"
-      patterns: "*.repo"
-    register: repos
-
-  - name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: 'mirrorlist'
-      replace: '#mirrorlist'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: '#baseurl=http://mirror.centos.org'
-      replace: 'baseurl=http://vault.centos.org'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Update dnf RHEL8
+  - name: Enable powertools on oracle linux 9
     become: true
-    command: dnf update -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+    command: dnf config-manager --set-enabled ol9_codeready_builder
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
 
-  - name: Disable dnf module for RHEL8
+  - name: Disable postgresql module for RHEL8
     become: true
     command: dnf module disable postgresql -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-  - name: Disable llvm-toolset dnf module for RHEL8
+  - name: Disable llvm-toolset for RHEL8
     become: true
     command: dnf module disable llvm-toolset -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
@@ -81,18 +60,6 @@
       - percona-postgresql-pltcl-12-dbgsym
     when: ansible_os_family == "Debian"
 
-  - name: install Percona Platform for PostgreSQL deb packages
-    apt:
-      name: "{{ packages }}"
-      update_cache: yes
-      state: latest
-    vars:
-      packages:
-      - percona-postgresql-plpython3-12
-      - percona-postgresql-plpython3-12-dbgsym
-    when:
-      - ansible_os_family == "Debian"
-
   - name: install Percona Platform for PostgreSQL rpm packages for RHEL
     yum:
       name: "{{ packages }}"
@@ -119,15 +86,6 @@
       - percona-postgresql12-test
       - percona-postgresql12-debuginfo
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
-
-  - name: DNF clean RHEL
-    command: sudo dnf module disable postgresql -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Disable llvm-toolset dnf module for RHEL8
-    become: true
-    command: dnf module disable llvm-toolset -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
   - name: install Percona Platform for PostgreSQL rpm packages for RHEL
     yum:
@@ -164,3 +122,37 @@
         - percona-postgresql12-pltcl-debuginfo
         - percona-postgresql12-server-debuginfo
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+
+  - name: install Percona Platform for PostgreSQL rpm packages for RHEL
+    yum:
+      name: "{{ packages }}"
+      state: latest
+      update_cache: yes
+      allow_downgrade: yes
+    vars:
+      packages:
+        - percona-postgresql-client-common
+        - percona-postgresql-common
+        - percona-postgresql-server-dev-all
+        - percona-postgresql12
+        - percona-postgresql12-contrib
+        - percona-postgresql12-debuginfo
+        - percona-postgresql12-devel
+        - percona-postgresql12-docs
+        - percona-postgresql12-libs
+        - percona-postgresql12-llvmjit
+        - percona-postgresql12-plperl
+        - percona-postgresql12-plpython3
+        - percona-postgresql12-pltcl
+        - percona-postgresql12-server
+        - percona-postgresql12-test
+        - percona-postgresql12-contrib-debuginfo
+        - percona-postgresql12-debuginfo
+        - percona-postgresql12-debugsource
+        - percona-postgresql12-devel-debuginfo
+        - percona-postgresql12-libs-debuginfo
+        - percona-postgresql12-plperl-debuginfo
+        - percona-postgresql12-plpython3-debuginfo
+        - percona-postgresql12-pltcl-debuginfo
+        - percona-postgresql12-server-debuginfo
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"

--- a/tasks/install_ppg12_tools.yml
+++ b/tasks/install_ppg12_tools.yml
@@ -169,6 +169,13 @@
       allow_downgrade: yes
     when: ansible_os_family == "RedHat"
 
+  - name: Install python3-pip
+    yum:
+      name: python3-pip
+      state: latest
+      update_cache: yes
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
   - name: Install python3 module - patroni[etcd]
     become: true
     command: python3 -m pip install patroni[etcd]
@@ -223,6 +230,27 @@
       update_cache: yes
     when: ansible_os_family == "Debian"
 
+  - name: Install CPAN
+    become: true
+    command: yum -y install perl-CPAN
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
+  - name: Install perl-App-cpanminus
+    become: true
+    command: yum -y install perl-App-cpanminus
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
+  - name: Install perl module Benchmark
+    become: true
+    command: cpanm Benchmark
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
   - name: Install percona-pgaudit12_set_user RHEL
     yum:
       name: percona-pgaudit12_set_user
@@ -268,7 +296,8 @@
       packages:
         - percona-pgpool-II-pg12
         - percona-pgpool-II-pg12-extensions
-    when: ansible_os_family == "RedHat"
+    when: (ansible_os_family == "RedHat" and pg_version_to_install is not defined) or
+      (ansible_os_family == "RedHat" and pg_version_to_install | string is version('12.14', '>=', strict=True))
 
   - name: Install percona-pgpool Debian
     apt:
@@ -279,7 +308,8 @@
       packages:
         - percona-pgpool2
         - libpgpool2
-    when: ansible_os_family == "Debian"
+    when: (ansible_os_family == "Debian" and pg_version_to_install is not defined) or
+      (ansible_os_family == "Debian" and pg_version_to_install | string is version('12.14', '>=', strict=True))
 
   - name: Install percona-wal2json12 RHEL
     yum:
@@ -586,14 +616,16 @@
       name: pgpool
       state: started
       enabled: yes
-    when: ansible_os_family == "RedHat"
+    when: (ansible_os_family == "RedHat" and pg_version_to_install is not defined) or
+      (ansible_os_family == "RedHat" and pg_version_to_install | string is version('12.14', '>=', strict=True))
 
   - name: Start pgpool service
     service:
       name: percona-pgpool2
       state: started
       enabled: yes
-    when: ansible_os_family == "Debian"
+    when: (ansible_os_family == "Debian" and pg_version_to_install is not defined) or
+      (ansible_os_family == "Debian" and pg_version_to_install | string is version('12.14', '>=', strict=True))
 
   - name: Add user postgres to sudoers
     user:

--- a/tasks/install_ppg13.yml
+++ b/tasks/install_ppg13.yml
@@ -5,11 +5,6 @@
       state: present
     when: ansible_os_family == "RedHat"
 
-  - name: Clean dnf RHEL8
-    become: true
-    command: dnf clean all -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
   - name: Clean dnf oracle linux
     become: true
     command: dnf clean all -y


### PR DESCRIPTION
1. Move ppg-12 centos8 setup to oracle linux 8.
2. Add oracle linux 9 platform to ppg-12.
3. Add check for support of pgpool version 12.14 and above only.
4. Installation of pip module on ol-9.
5. Tweaks for tests in test_bvt.py to accommodate the corner cases.  