### PR TITLE
ppg-11 changes in this commit are following:

### DIFF
--- a/ppg/pg-11/molecule/ol-8/molecule.yml
+++ b/ppg/pg-11/molecule/ol-8/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: ol8-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-065e2293a3df4c870
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-11/molecule/ol-9/molecule.yml
+++ b/ppg/pg-11/molecule/ol-9/molecule.yml
@@ -4,12 +4,12 @@ dependency:
 driver:
   name: ec2
 platforms:
-  - name: centos8-${BUILD_NUMBER}-${JOB_NAME}
+  - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0e337c7f9752d9d34
+    image: ami-02952e732e6126584
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
-    ssh_user: centos
+    ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker
@@ -20,7 +20,7 @@ provisioner:
     create: ../../../../playbooks/create.yml
     destroy: ../../../../playbooks/destroy.yml
     prepare: ../../../../playbooks/prepare.yml
-    cleanup: ../../playbooks/cleanup.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
     converge: ../../playbooks/playbook.yml
 verifier:
   name: testinfra

--- a/ppg/tests/tests_ppg/test_bvt.py
+++ b/ppg/tests/tests_ppg/test_bvt.py
@@ -114,9 +114,10 @@ def test_rpm_package_is_installed(host, package):
         if host.system_info.release == "7":
             pytest.skip("Only for RHEL8 tests")
         if package in [
-                'percona-postgresql12-plpython', "percona-postgresql12-plpython-debuginfo"] and \
-                settings.MAJOR_VER in ["12"] and host.system_info.release.startswith("9"):
-            pytest.skip("Skipping for OL 9 based ppg 12")
+                'percona-postgresql12-plpython', "percona-postgresql12-plpython-debuginfo", 
+                "percona-postgresql11-plpython", "percona-postgresql11-plpython-debuginfo"] and \
+                settings.MAJOR_VER in ["12","11"] and host.system_info.release.startswith("9"):
+            pytest.skip("Skipping for OL 9 based ppg 12 & 11")
         pkg = host.package(package)
         assert pkg.is_installed
         if package not in ["percona-postgresql-client-common", "percona-postgresql-common"]:
@@ -231,46 +232,55 @@ def test_insert_data(insert_data):
 
 
 @pytest.mark.upgrade
-def test_extenstions_list(extension_list, host):
+@pytest.mark.parametrize("extension", EXTENSIONS)
+def test_extenstions_list(extension_list, host, extension):
     ds = host.system_info.distribution
-    for extension in EXTENSIONS:
-        if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
-            if "python3" in extension:
-                pytest.skip("Skipping python3 extensions for Centos or RHEL")
-            if extension in [
-                'plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
-                'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u'] and settings.MAJOR_VER in ["13", "14", "15"]:
-                pytest.skip("Skipping extensions for Centos or RHEL")
-            if extension in [
-                'plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
-                'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u'] and settings.MAJOR_VER in ["12"] and host.system_info.release.startswith("9"):
-                pytest.skip("Skipping python2 extensions for OL 9 based ppg 12")
-        if ds.lower() in ['debian', 'ubuntu'] and os.getenv("VERSION") in SKIPPED_DEBIAN:
-            if extension in ['plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
-                             'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u']:
-                pytest.skip("Skipping python2 extensions for DEB based in pg: " + os.getenv("VERSION"))
-        assert extension in extension_list
+    if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
+        # if "python3" in extension:
+        #     pytest.skip("Skipping python3 extensions for Centos or RHEL")
+        if extension in [
+            'plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
+            'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u'] and settings.MAJOR_VER in ["13", "14", "15"]:
+            pytest.skip("Skipping extension " + extension + " for Centos or RHEL")
+        if extension in [
+            'plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
+            'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u'] and settings.MAJOR_VER in ["12","11"] and \
+            host.system_info.release.startswith("9"):
+            pytest.skip("Skipping extension " + extension + " for OL 9 based ppg 12 & 11")
+    if ds.lower() in ['debian', 'ubuntu'] and os.getenv("VERSION") in SKIPPED_DEBIAN:
+        if extension in ['plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
+                            'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u']:
+            pytest.skip("Skipping extension " + extension + " for DEB based in pg: " + os.getenv("VERSION"))
+    assert extension in extension_list
 
 
 @pytest.mark.parametrize("extension", EXTENSIONS)
 def test_enable_extension(host, extension):
     ds = host.system_info.distribution
     if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
-        if "python3" in extension:
-            pytest.skip("Skipping python3 extensions for Centos or RHEL")
+        # if "python3" in extension:
+        #     pytest.skip("Skipping python3 extensions for Centos or RHEL")
+        if extension in ['hstore_plpython3u','jsonb_plpython3u', 'ltree_plpython3u']:
+            pytest.skip("Skipping " + extension + " extension for Centos or RHEL")
         if extension in [
             'plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
-            'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u'] and settings.MAJOR_VER in ["13", "14", "15"]:
-            pytest.skip("Skipping extensions for Centos or RHEL")
+            'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u', 'hstore_plpython3u',
+            'jsonb_plpython3u', 'ltree_plpython3u'] and settings.MAJOR_VER in ["13", "14", "15"]:
+            pytest.skip("Skipping extension " + extension + " for Centos or RHEL")
         if extension in [
             'plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
-            'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u'] and settings.MAJOR_VER in ["12"] and host.system_info.release.startswith("9"):
-            pytest.skip("Skipping python2 extensions for OL 9 based ppg 12")
+            'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u', 'hstore_plpython3u',
+            'jsonb_plpython3u', 'ltree_plpython3u'] and settings.MAJOR_VER in ["12","11"] and \
+            host.system_info.release.startswith("9"):
+            pytest.skip("Skipping extension " + extension + " for OL 9 based ppg 12 & 11")
 
     if ds.lower() in ['debian', 'ubuntu'] and os.getenv("VERSION") in SKIPPED_DEBIAN:
         if extension in ['plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
-                         'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u']:
-            pytest.skip("Skipping python2 extensions for DEB based in pg: " + os.getenv("VERSION"))
+                         'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u', 'hstore_plpython3u',
+                         'jsonb_plpython3u', 'ltree_plpython3u']:
+            pytest.skip("Skipping extension " + extension + " for DEB based in pg: " + os.getenv("VERSION"))
+    if ds.lower() in ['ubuntu'] and extension in ['hstore_plpython3u','jsonb_plpython3u', 'ltree_plpython3u']:
+            pytest.skip("Skipping extension " + extension + " for Ubuntu based in pg: " + os.getenv("VERSION"))
     with host.sudo("postgres"):
         install_extension = host.run("psql -c 'CREATE EXTENSION \"{}\";'".format(extension))
         assert install_extension.rc == 0, install_extension.stderr
@@ -286,21 +296,29 @@ def test_enable_extension(host, extension):
 def test_drop_extension(host, extension):
     ds = host.system_info.distribution
     if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
-        if "python3" in extension:
-            pytest.skip("Skipping python3 extensions for Centos or RHEL")
+        # if "python3" in extension:
+        #     pytest.skip("Skipping python3 extensions for Centos or RHEL")
+        if extension in ['hstore_plpython3u','jsonb_plpython3u', 'ltree_plpython3u']:
+            pytest.skip("Skipping " + extension + " extension for Centos or RHEL")
         if extension in [
             'plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
-            'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u'] and settings.MAJOR_VER in ["13", "14", "15"]:
-            pytest.skip("Skipping extensions for Centos or RHEL")
+            'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u', 'hstore_plpython3u',
+            'jsonb_plpython3u', 'ltree_plpython3u'] and settings.MAJOR_VER in ["13", "14", "15"]:
+            pytest.skip("Skipping extension " + extension + " for Centos or RHEL")
         if extension in [
             'plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
-            'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u'] and settings.MAJOR_VER in ["12"] and host.system_info.release.startswith("9"):
-            pytest.skip("Skipping python2 extensions for OL 9 based ppg 12")
+            'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u', 'hstore_plpython3u',
+            'jsonb_plpython3u', 'ltree_plpython3u'] and settings.MAJOR_VER in ["12","11"] and \
+            host.system_info.release.startswith("9"):
+            pytest.skip("Skipping extension " + extension + " for OL 9 based ppg 12 & 11")
 
     if ds.lower() in ['debian', 'ubuntu'] and os.getenv("VERSION") in SKIPPED_DEBIAN:
         if extension in ['plpythonu', "plpython2u", 'jsonb_plpython2u', 'ltree_plpython2u', 'jsonb_plpythonu',
-                         'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u']:
-            pytest.skip("Skipping python2 extensions for DEB based in pg: " + os.getenv("VERSION"))
+                         'ltree_plpythonu', 'hstore_plpythonu', 'hstore_plpython2u', 'hstore_plpython3u',
+                         'jsonb_plpython3u', 'ltree_plpython3u']:
+            pytest.skip("Skipping extension " + extension + " for DEB based in pg: " + os.getenv("VERSION"))
+    if ds.lower() in ['ubuntu'] and extension in ['hstore_plpython3u','jsonb_plpython3u', 'ltree_plpython3u']:
+            pytest.skip("Skipping extension " + extension + " for Ubuntu based in pg: " + os.getenv("VERSION"))
     with host.sudo("postgres"):
         drop_extension = host.run("psql -c 'DROP EXTENSION \"{}\";'".format(extension))
         assert drop_extension.rc == 0, drop_extension.stderr
@@ -353,13 +371,13 @@ def test_language(host, language):
     dists = ['debian', 'ubuntu']
     ds = host.system_info.distribution
     with host.sudo("postgres"):
-        if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
-            if "python3" in language:
-                pytest.skip("Skipping python3 language for Centos or RHEL")
+        # if ds.lower() in ["redhat", "centos", "rhel", "ol"]:
+        #     if "python3" in language:
+        #         pytest.skip("Skipping python3 language for Centos or RHEL")
         if ds.lower() in dists and language in ['plpythonu', "plpython2u"] or settings.MAJOR_VER in ["13", "14", "15"]:
             pytest.skip("Skipping python2 extensions for DEB based in 12.* and all centos 13")
-        if language in ['plpythonu', "plpython2u"] and settings.MAJOR_VER in ["12"] and host.system_info.release.startswith("9"):
-            pytest.skip("Skipping python2 extensions for OL 9 based ppg 12")
+        if language in ['plpythonu', "plpython2u"] and settings.MAJOR_VER in ["12","11"] and host.system_info.release.startswith("9"):
+            pytest.skip("Skipping python2 extensions for OL 9 based ppg 12 & 11")
         lang = host.run("psql -c 'CREATE LANGUAGE {};'".format(language))
         assert lang.rc == 0, lang.stderr
         assert lang.stdout.strip("\n") in ["CREATE LANGUAGE", "CREATE EXTENSION"], lang.stdout

--- a/ppg/tests/versions/extensions.py
+++ b/ppg/tests/versions/extensions.py
@@ -98,7 +98,11 @@ RPM12_EXTENSIONS = ["hstore",
                     "plpython2u",
                     "plpythonu",
                     "plperl",
-                    "pg_stat_monitor"
+                    "pg_stat_monitor",
+                    "hstore_plpython3u",
+                    "jsonb_plpython3u",
+                    "ltree_plpython3u",
+                    "plpython3u"
                     ]
 
 RPM13_EXTENSIONS = ["hstore",
@@ -148,7 +152,11 @@ RPM13_EXTENSIONS = ["hstore",
                     "pltcl",
                     "pltclu",
                     "plperl",
-                    "pg_stat_monitor"
+                    "pg_stat_monitor",
+                    "hstore_plpython3u",
+                    "jsonb_plpython3u",
+                    "ltree_plpython3u",
+                    "plpython3u"
                     ]
 
 
@@ -257,7 +265,11 @@ RPM11_EXTENSIONS = ["fuzzystrmatch",
                     "tsm_system_time",
                     "unaccent",
                     "uuid-ossp",
-                    "pg_stat_monitor"
+                    "pg_stat_monitor",
+                    "hstore_plpython3u",
+                    "jsonb_plpython3u",
+                    "ltree_plpython3u",
+                    "plpython3u"
                     ]
 
 

--- a/tasks/install_ppg11.yml
+++ b/tasks/install_ppg11.yml
@@ -6,49 +6,28 @@
       state: present
     when: ansible_os_family == "RedHat"
 
-  - name: Clean dnf RHEL8
+  - name: Clean dnf oracle linux
     become: true
     command: dnf clean all -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+    when: ansible_os_family == "RedHat" and
+      (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
 
-  - name: Enable powertools RHEL8
+  - name: Enable powertools on oracle linux 8
     become: true
-    command: dnf config-manager --set-enabled powertools
+    command: dnf config-manager --set-enabled ol8_codeready_builder
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-  - name: Find all of the files inside /etc/yum.repos.d directory
-    find:
-      paths: "/etc/yum.repos.d/"
-      patterns: "*.repo"
-    register: repos
-
-  - name: Comment 'mirrorlist' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: 'mirrorlist'
-      replace: '#mirrorlist'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Replace 'baseurl' in /etc/yum.repos.d/*.repo files
-    replace:
-      path: "{{ item.path }}"
-      regexp: '#baseurl=http://mirror.centos.org'
-      replace: 'baseurl=http://vault.centos.org'
-    with_items: "{{ repos.files }}"
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
-  - name: Update dnf RHEL8
+  - name: Enable powertools on oracle linux 9
     become: true
-    command: dnf update -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+    command: dnf config-manager --set-enabled ol9_codeready_builder
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
 
-  - name: Disable dnf module for RHEL8
+  - name: Disable postgresql module for RHEL8
     become: true
     command: dnf module disable postgresql -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-  - name: Disable llvm-toolset dnf module for RHEL8
+  - name: Disable llvm-toolset for RHEL8
     become: true
     command: dnf module disable llvm-toolset -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
@@ -122,10 +101,6 @@
       - percona-postgresql11-debuginfo
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
 
-  - name: DNF clean RHEL
-    command: sudo dnf module disable postgresql -y
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
-
   - name: install Percona Platform for PostgreSQL rpm packages for RHEL
     yum:
       name: "{{ packages }}"
@@ -160,3 +135,36 @@
         - percona-postgresql11-pltcl-debuginfo
         - percona-postgresql11-server-debuginfo
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+
+  - name: install Percona Platform for PostgreSQL rpm packages for RHEL
+    yum:
+      name: "{{ packages }}"
+      state: latest
+      update_cache: yes
+    vars:
+      packages:
+        - percona-postgresql-client-common
+        - percona-postgresql-common
+        - percona-postgresql-server-dev-all
+        - percona-postgresql11
+        - percona-postgresql11-contrib
+        - percona-postgresql11-debuginfo
+        - percona-postgresql11-devel
+        - percona-postgresql11-docs
+        - percona-postgresql11-libs
+        - percona-postgresql11-llvmjit
+        - percona-postgresql11-plperl
+        - percona-postgresql11-plpython3
+        - percona-postgresql11-pltcl
+        - percona-postgresql11-server
+        - percona-postgresql11-test
+        - percona-postgresql11-contrib-debuginfo
+        - percona-postgresql11-debuginfo
+        - percona-postgresql11-debugsource
+        - percona-postgresql11-devel-debuginfo
+        - percona-postgresql11-libs-debuginfo
+        - percona-postgresql11-plperl-debuginfo
+        - percona-postgresql11-plpython3-debuginfo
+        - percona-postgresql11-pltcl-debuginfo
+        - percona-postgresql11-server-debuginfo
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"

--- a/tasks/install_ppg11_tools.yml
+++ b/tasks/install_ppg11_tools.yml
@@ -102,6 +102,27 @@
       update_cache: yes
     when: ansible_os_family == "Debian"
 
+  - name: Install CPAN
+    become: true
+    command: yum -y install perl-CPAN
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
+  - name: Install perl-App-cpanminus
+    become: true
+    command: yum -y install perl-App-cpanminus
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
+  - name: Install perl module Benchmark
+    become: true
+    command: cpanm Benchmark
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
   - name: Install percona-pgaudit11_set_user RHEL
     yum:
       name: percona-pgaudit11_set_user
@@ -149,7 +170,8 @@
       packages:
         - percona-pgpool-II-pg11
         - percona-pgpool-II-pg11-extensions
-    when: ansible_os_family == "RedHat"
+    when: (ansible_os_family == "RedHat" and pg_version_to_install is not defined) or
+      (ansible_os_family == "RedHat" and pg_version_to_install | string is version('11.19', '>=', strict=True))
 
   - name: Install percona-pgpool Debian
     apt:
@@ -160,7 +182,8 @@
       packages:
         - percona-pgpool2
         - libpgpool2
-    when: ansible_os_family == "Debian"
+    when: (ansible_os_family == "Debian" and pg_version_to_install is not defined) or
+      (ansible_os_family == "Debian" and pg_version_to_install | string is version('11.19', '>=', strict=True))
 
   - name: Install percona-wal2json11 RHEL
     yum:
@@ -315,6 +338,13 @@
       update_cache: yes
       allow_downgrade: yes
     when: ansible_os_family == "RedHat"
+
+  - name: Install python3-pip
+    yum:
+      name: python3-pip
+      state: latest
+      update_cache: yes
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
 
   - name: Install python3 module - patroni[etcd]
     become: true
@@ -609,14 +639,16 @@
       name: pgpool
       state: started
       enabled: yes
-    when: ansible_os_family == "RedHat"
+    when: (ansible_os_family == "RedHat" and pg_version_to_install is not defined) or
+      (ansible_os_family == "RedHat" and pg_version_to_install | string is version('11.19', '>=', strict=True))
 
   - name: Start pgpool service
     service:
       name: percona-pgpool2
       state: started
       enabled: yes
-    when: ansible_os_family == "Debian"
+    when: (ansible_os_family == "Debian" and pg_version_to_install is not defined) or
+      (ansible_os_family == "Debian" and pg_version_to_install | string is version('11.19', '>=', strict=True))
 
   - name: Add user postgres to sudoers
     user:


### PR DESCRIPTION
1. Move ppg-11 centos8 setup to oracle linux 8.
2. Add oracle linux 9 platform to ppg-11.
3. Add check for support of pgpool version 11.19 and above only.
4. Installation of pip module on ol-9.
5. Tweaks to text_bvt.py to fix failures.
6. Enable plpython3 extension to be verified.