### PR TITLE
Updated AMIs for debian-10 & 11. Old AMIs were 2 years old and not av…

### DIFF
--- a/ppg/pg-11-components-with-vanila/molecule/debian-10/molecule.yml
+++ b/ppg/pg-11-components-with-vanila/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-11-components-with-vanila/molecule/debian-11/molecule.yml
+++ b/ppg/pg-11-components-with-vanila/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-11-meta-ha/molecule/debian-10/molecule.yml
+++ b/ppg/pg-11-meta-ha/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-11-meta-ha/molecule/debian-11/molecule.yml
+++ b/ppg/pg-11-meta-ha/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-11-meta-server/molecule/debian-10/molecule.yml
+++ b/ppg/pg-11-meta-server/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-11-meta-server/molecule/debian-11/molecule.yml
+++ b/ppg/pg-11-meta-server/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-11-minor-upgrade/molecule/debian-10/molecule.yml
+++ b/ppg/pg-11-minor-upgrade/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-11-minor-upgrade/molecule/debian-11/molecule.yml
+++ b/ppg/pg-11-minor-upgrade/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-11-setup/molecule/debian-10/molecule.yml
+++ b/ppg/pg-11-setup/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-11-setup/molecule/debian-11/molecule.yml
+++ b/ppg/pg-11-setup/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-11-with-vanila-components/molecule/debian-10/molecule.yml
+++ b/ppg/pg-11-with-vanila-components/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-11-with-vanila-components/molecule/debian-11/molecule.yml
+++ b/ppg/pg-11-with-vanila-components/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-11/molecule/debian-10/molecule.yml
+++ b/ppg/pg-11/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-11/molecule/debian-11/molecule.yml
+++ b/ppg/pg-11/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-12-components-with-vanila/molecule/debian-10/molecule.yml
+++ b/ppg/pg-12-components-with-vanila/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-12-components-with-vanila/molecule/debian-11/molecule.yml
+++ b/ppg/pg-12-components-with-vanila/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-12-full-major-upgrade/molecule/debian-10/molecule.yml
+++ b/ppg/pg-12-full-major-upgrade/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-12-full-major-upgrade/molecule/debian-11/molecule.yml
+++ b/ppg/pg-12-full-major-upgrade/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-12-major-upgrade/molecule/debian-10/molecule.yml
+++ b/ppg/pg-12-major-upgrade/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-12-major-upgrade/molecule/debian-11/molecule.yml
+++ b/ppg/pg-12-major-upgrade/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-12-meta-ha/molecule/debian-10/molecule.yml
+++ b/ppg/pg-12-meta-ha/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-12-meta-ha/molecule/debian-11/molecule.yml
+++ b/ppg/pg-12-meta-ha/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-12-meta-server/molecule/debian-10/molecule.yml
+++ b/ppg/pg-12-meta-server/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-12-meta-server/molecule/debian-11/molecule.yml
+++ b/ppg/pg-12-meta-server/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-12-minor-upgrade/molecule/debian-10/molecule.yml
+++ b/ppg/pg-12-minor-upgrade/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-12-minor-upgrade/molecule/debian-11/molecule.yml
+++ b/ppg/pg-12-minor-upgrade/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-12-setup/molecule/debian-10/molecule.yml
+++ b/ppg/pg-12-setup/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-12-setup/molecule/debian-11/molecule.yml
+++ b/ppg/pg-12-setup/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-12-with-vanila-components/molecule/debian-10/molecule.yml
+++ b/ppg/pg-12-with-vanila-components/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-12-with-vanila-components/molecule/debian-11/molecule.yml
+++ b/ppg/pg-12-with-vanila-components/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-12/molecule/debian-10/molecule.yml
+++ b/ppg/pg-12/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-12/molecule/debian-11/molecule.yml
+++ b/ppg/pg-12/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-13-components-with-vanila/molecule/debian-10/molecule.yml
+++ b/ppg/pg-13-components-with-vanila/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-13-components-with-vanila/molecule/debian-11/molecule.yml
+++ b/ppg/pg-13-components-with-vanila/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-13-major-upgrade/molecule/debian-10/molecule.yml
+++ b/ppg/pg-13-major-upgrade/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-13-major-upgrade/molecule/debian-11/molecule.yml
+++ b/ppg/pg-13-major-upgrade/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-13-meta-ha/molecule/debian-10/molecule.yml
+++ b/ppg/pg-13-meta-ha/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-13-meta-ha/molecule/debian-11/molecule.yml
+++ b/ppg/pg-13-meta-ha/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-13-meta-server/molecule/debian-10/molecule.yml
+++ b/ppg/pg-13-meta-server/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-13-meta-server/molecule/debian-11/molecule.yml
+++ b/ppg/pg-13-meta-server/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-13-minor-upgrade/molecule/debian-10/molecule.yml
+++ b/ppg/pg-13-minor-upgrade/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-13-minor-upgrade/molecule/debian-11/molecule.yml
+++ b/ppg/pg-13-minor-upgrade/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-13-setup/molecule/debian-10/molecule.yml
+++ b/ppg/pg-13-setup/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-13-setup/molecule/debian-11/molecule.yml
+++ b/ppg/pg-13-setup/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-13-vanila-upgrade/molecule/debian-10/molecule.yml
+++ b/ppg/pg-13-vanila-upgrade/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-13-vanila-upgrade/molecule/debian-11/molecule.yml
+++ b/ppg/pg-13-vanila-upgrade/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-13-with-vanila-components/molecule/debian-10/molecule.yml
+++ b/ppg/pg-13-with-vanila-components/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-13-with-vanila-components/molecule/debian-11/molecule.yml
+++ b/ppg/pg-13-with-vanila-components/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-13/molecule/debian-10/molecule.yml
+++ b/ppg/pg-13/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-13/molecule/debian-11/molecule.yml
+++ b/ppg/pg-13/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-14-components-with-vanila/molecule/debian-10/molecule.yml
+++ b/ppg/pg-14-components-with-vanila/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-14-components-with-vanila/molecule/debian-11/molecule.yml
+++ b/ppg/pg-14-components-with-vanila/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-14-major-upgrade/molecule/debian-10/molecule.yml
+++ b/ppg/pg-14-major-upgrade/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-14-major-upgrade/molecule/debian-11/molecule.yml
+++ b/ppg/pg-14-major-upgrade/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-14-meta-ha/molecule/debian-10/molecule.yml
+++ b/ppg/pg-14-meta-ha/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-14-meta-ha/molecule/debian-11/molecule.yml
+++ b/ppg/pg-14-meta-ha/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-14-meta-server/molecule/debian-10/molecule.yml
+++ b/ppg/pg-14-meta-server/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-14-meta-server/molecule/debian-11/molecule.yml
+++ b/ppg/pg-14-meta-server/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-14-minor-upgrade/molecule/debian-10/molecule.yml
+++ b/ppg/pg-14-minor-upgrade/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-14-minor-upgrade/molecule/debian-11/molecule.yml
+++ b/ppg/pg-14-minor-upgrade/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-14-setup/molecule/debian-10/molecule.yml
+++ b/ppg/pg-14-setup/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-14-setup/molecule/debian-11/molecule.yml
+++ b/ppg/pg-14-setup/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-14-with-vanila-components/molecule/debian-10/molecule.yml
+++ b/ppg/pg-14-with-vanila-components/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-14-with-vanila-components/molecule/debian-11/molecule.yml
+++ b/ppg/pg-14-with-vanila-components/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-14/molecule/debian-10/molecule.yml
+++ b/ppg/pg-14/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-14/molecule/debian-11/molecule.yml
+++ b/ppg/pg-14/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-15-components-with-vanila/molecule/debian-10/molecule.yml
+++ b/ppg/pg-15-components-with-vanila/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-15-components-with-vanila/molecule/debian-11/molecule.yml
+++ b/ppg/pg-15-components-with-vanila/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-15-major-upgrade/molecule/debian-10/molecule.yml
+++ b/ppg/pg-15-major-upgrade/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-15-major-upgrade/molecule/debian-11/molecule.yml
+++ b/ppg/pg-15-major-upgrade/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-15-meta-ha/molecule/debian-10/molecule.yml
+++ b/ppg/pg-15-meta-ha/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-15-meta-ha/molecule/debian-11/molecule.yml
+++ b/ppg/pg-15-meta-ha/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-15-meta-server/molecule/debian-10/molecule.yml
+++ b/ppg/pg-15-meta-server/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-15-meta-server/molecule/debian-11/molecule.yml
+++ b/ppg/pg-15-meta-server/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-15-minor-upgrade/molecule/debian-10/molecule.yml
+++ b/ppg/pg-15-minor-upgrade/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-15-minor-upgrade/molecule/debian-11/molecule.yml
+++ b/ppg/pg-15-minor-upgrade/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-15-setup/molecule/debian-10/molecule.yml
+++ b/ppg/pg-15-setup/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-15-setup/molecule/debian-11/molecule.yml
+++ b/ppg/pg-15-setup/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-15-with-vanila-components/molecule/debian-10/molecule.yml
+++ b/ppg/pg-15-with-vanila-components/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-15-with-vanila-components/molecule/debian-11/molecule.yml
+++ b/ppg/pg-15-with-vanila-components/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.micro
     ssh_user: admin

--- a/ppg/pg-15/molecule/debian-10/molecule.yml
+++ b/ppg/pg-15/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0f41e297b3c53fab8
+    image: ami-0b0feb0b7d24e609b
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-15/molecule/debian-11/molecule.yml
+++ b/ppg/pg-15/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-007428d10865c9957
+    image: ami-0b2bcb9cb754576f2
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/tasks/install_ppg_meta_ha.yml
+++ b/tasks/install_ppg_meta_ha.yml
@@ -48,7 +48,7 @@
       update_cache: yes
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
 
-  - name: Install python3 module - patroni[etcd]
-    become: true
-    command: python3 -m pip install patroni[etcd]
-    when: ansible_os_family == "RedHat"
+  # - name: Install python3 module - patroni[etcd]
+  #   become: true
+  #   command: python3 -m pip install patroni[etcd]
+  #   when: ansible_os_family == "RedHat"


### PR DESCRIPTION
Updated AMIs for debian 10 & 11. Old AMIs were 2 years old and not available for debian 11 anymore. Also, for patroni tests, disabled patroni etcd installation via pip.