### PR TITLE
Following multiple tasks are part of this commit covering ppg 11~15:

### DIFF
--- a/pg_stat_monitor/ppg-11/molecule/default/molecule.yml
+++ b/pg_stat_monitor/ppg-11/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.medium
+    instance_type: t2.xlarge
     ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:

--- a/pg_stat_monitor/ppg-12/molecule/default/molecule.yml
+++ b/pg_stat_monitor/ppg-12/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.medium
+    instance_type: t2.xlarge
     ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:

--- a/pg_stat_monitor/ppg-13/molecule/default/molecule.yml
+++ b/pg_stat_monitor/ppg-13/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.medium
+    instance_type: t2.xlarge
     ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:

--- a/pg_stat_monitor/ppg-14/molecule/default/molecule.yml
+++ b/pg_stat_monitor/ppg-14/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.medium
+    instance_type: t2.xlarge
     ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:

--- a/pg_stat_monitor/ppg-15/molecule/default/molecule.yml
+++ b/pg_stat_monitor/ppg-15/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-065e2293a3df4c870
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.medium
+    instance_type: t2.xlarge
     ssh_user: ec2-user
     root_device_name: /dev/sda1
     instance_tags:

--- a/pgbackrest/ppg-11/molecule/default/molecule.yml
+++ b/pgbackrest/ppg-11/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-0be656e75e69af1a9
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.medium
+    instance_type: t2.xlarge
     ssh_user: ubuntu
     root_device_name: /dev/sda1
     instance_tags:

--- a/pgbackrest/ppg-11/tasks/main.yml
+++ b/pgbackrest/ppg-11/tasks/main.yml
@@ -10,6 +10,9 @@
     state: latest
   vars:
     packages:
+      - make
+      - gcc
+      - pkg-config
       - apt-transport-https
       - ca-certificates
       - curl
@@ -25,7 +28,6 @@
       - libssl-dev
       - libxml2-dev
       - libpq-dev
-      - pkg-config
       - valgrind
       - liblz4-dev
       - liblz4-tool
@@ -35,11 +37,14 @@
       - libbz2-dev
       - libyaml-dev
       - meson
+      - libz-dev
+      - libyaml-dev
+      - libssh2-1-dev
+      - psmisc
   retries: 60
   delay: 10
   register: result
   until: result is not failed
-  when: ansible_os_family == "Debian"
 
 - name: install Percona Platform for PostgreSQL deb packages
   apt:
@@ -61,14 +66,13 @@
     - percona-postgresql-pltcl-11
     - percona-postgresql-server-dev-11
     - percona-postgresql-server-dev-all
-  when: ansible_os_family == "Debian"
 
 - name: Clone pgbackrest sources
   become_user: postgres
   git:
     repo: "{{ repo }}"
     version: "{{ version }}"
-    dest: /var/lib/postgresql/pgbackrest
+    dest: /tmp/pgbackrest
   vars:
     repo: "{{ lookup('env', 'COMPONENT_REPO') }}"
     version: "{{ lookup('env', 'COMPONENT_VERSION') }}"
@@ -84,13 +88,18 @@
     name: postgresql
     state: stopped
 
+- name: Make sure tcp port 80 is free
+  become: true
+  command: sudo fuser -k 80/tcp
+  ignore_errors: true
+
 - name: Run pgbackrest regression
   become_user: postgres
-  command: pgbackrest/test/test.pl --psql-bin=/usr/lib/postgresql/15/bin \
+  command: pgbackrest/test/test.pl --psql-bin=/usr/lib/postgresql/11/bin \
     --no-valgrind --log-level-test-file=off --no-coverage-report \
-    --module=command --module=storage --vm-out --vm=none --no-coverage
+    --module=command --module=storage --vm-out --vm=none --no-coverage --test-path /tmp
   args:
-    chdir: "/var/lib/postgresql"
+    chdir: "/tmp"
   register: results
 
 - debug:

--- a/pgbackrest/ppg-12/molecule/default/molecule.yml
+++ b/pgbackrest/ppg-12/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-0be656e75e69af1a9
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.medium
+    instance_type: t2.xlarge
     ssh_user: ubuntu
     root_device_name: /dev/sda1
     instance_tags:

--- a/pgbackrest/ppg-12/tasks/main.yml
+++ b/pgbackrest/ppg-12/tasks/main.yml
@@ -10,6 +10,9 @@
     state: latest
   vars:
     packages:
+      - make
+      - gcc
+      - pkg-config
       - apt-transport-https
       - ca-certificates
       - curl
@@ -25,7 +28,6 @@
       - libssl-dev
       - libxml2-dev
       - libpq-dev
-      - pkg-config
       - valgrind
       - liblz4-dev
       - liblz4-tool
@@ -35,11 +37,14 @@
       - libbz2-dev
       - libyaml-dev
       - meson
+      - libz-dev
+      - libyaml-dev
+      - libssh2-1-dev
+      - psmisc
   retries: 60
   delay: 10
   register: result
   until: result is not failed
-  when: ansible_os_family == "Debian"
 
 - name: install Percona Platform for PostgreSQL deb packages
   apt:
@@ -61,14 +66,13 @@
     - percona-postgresql-pltcl-12
     - percona-postgresql-server-dev-12
     - percona-postgresql-server-dev-all
-  when: ansible_os_family == "Debian"
 
 - name: Clone pgbackrest sources
   become_user: postgres
   git:
     repo: "{{ repo }}"
     version: "{{ version }}"
-    dest: /var/lib/postgresql/pgbackrest
+    dest: /tmp/pgbackrest
   vars:
     repo: "{{ lookup('env', 'COMPONENT_REPO') }}"
     version: "{{ lookup('env', 'COMPONENT_VERSION') }}"
@@ -84,13 +88,18 @@
     name: postgresql
     state: stopped
 
+- name: Make sure tcp port 80 is free
+  become: true
+  command: sudo fuser -k 80/tcp
+  ignore_errors: true
+
 - name: Run pgbackrest regression
   become_user: postgres
-  command: pgbackrest/test/test.pl --psql-bin=/usr/lib/postgresql/15/bin \
+  command: pgbackrest/test/test.pl --psql-bin=/usr/lib/postgresql/12/bin \
     --no-valgrind --log-level-test-file=off --no-coverage-report \
-    --module=command --module=storage --vm-out --vm=none --no-coverage
+    --module=command --module=storage --vm-out --vm=none --no-coverage --test-path /tmp
   args:
-    chdir: "/var/lib/postgresql"
+    chdir: "/tmp"
   register: results
 
 - debug:

--- a/pgbackrest/ppg-13/molecule/default/molecule.yml
+++ b/pgbackrest/ppg-13/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-0be656e75e69af1a9
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.medium
+    instance_type: t2.xlarge
     ssh_user: ubuntu
     root_device_name: /dev/sda1
     instance_tags:

--- a/pgbackrest/ppg-13/tasks/main.yml
+++ b/pgbackrest/ppg-13/tasks/main.yml
@@ -10,6 +10,9 @@
     state: latest
   vars:
     packages:
+      - make
+      - gcc
+      - pkg-config
       - apt-transport-https
       - ca-certificates
       - curl
@@ -25,7 +28,6 @@
       - libssl-dev
       - libxml2-dev
       - libpq-dev
-      - pkg-config
       - valgrind
       - liblz4-dev
       - liblz4-tool
@@ -35,12 +37,16 @@
       - libbz2-dev
       - libyaml-dev
       - meson
+      - libz-dev
+      - libyaml-dev
+      - libssh2-1-dev
+      - psmisc
   retries: 60
   delay: 10
   register: result
   until: result is not failed
 
-- name: install Percona Platform for PostgreSQL packages
+- name: install Percona Platform for PostgreSQL deb packages
   apt:
     name: "{{ packages }}"
     update_cache: yes
@@ -66,7 +72,7 @@
   git:
     repo: "{{ repo }}"
     version: "{{ version }}"
-    dest: /var/lib/postgresql/pgbackrest
+    dest: /tmp/pgbackrest
   vars:
     repo: "{{ lookup('env', 'COMPONENT_REPO') }}"
     version: "{{ lookup('env', 'COMPONENT_VERSION') }}"
@@ -82,13 +88,18 @@
     name: postgresql
     state: stopped
 
+- name: Make sure tcp port 80 is free
+  become: true
+  command: sudo fuser -k 80/tcp
+  ignore_errors: true
+
 - name: Run pgbackrest regression
   become_user: postgres
-  command: pgbackrest/test/test.pl --psql-bin=/usr/lib/postgresql/15/bin \
+  command: pgbackrest/test/test.pl --psql-bin=/usr/lib/postgresql/13/bin \
     --no-valgrind --log-level-test-file=off --no-coverage-report \
-    --module=command --module=storage --vm-out --vm=none --no-coverage
+    --module=command --module=storage --vm-out --vm=none --no-coverage --test-path /tmp
   args:
-    chdir: "/var/lib/postgresql"
+    chdir: "/tmp"
   register: results
 
 - debug:

--- a/pgbackrest/ppg-14/molecule/default/molecule.yml
+++ b/pgbackrest/ppg-14/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     region: eu-central-1
     image: ami-0be656e75e69af1a9
     vpc_subnet_id: subnet-085deaca8c1c59a4f
-    instance_type: t2.medium
+    instance_type: t2.xlarge
     ssh_user: ubuntu
     root_device_name: /dev/sda1
     instance_tags:

--- a/pgbackrest/ppg-14/tasks/main.yml
+++ b/pgbackrest/ppg-14/tasks/main.yml
@@ -10,6 +10,9 @@
     state: latest
   vars:
     packages:
+      - make
+      - gcc
+      - pkg-config
       - apt-transport-https
       - ca-certificates
       - curl
@@ -25,7 +28,6 @@
       - libssl-dev
       - libxml2-dev
       - libpq-dev
-      - pkg-config
       - valgrind
       - liblz4-dev
       - liblz4-tool
@@ -35,6 +37,10 @@
       - libbz2-dev
       - libyaml-dev
       - meson
+      - libz-dev
+      - libyaml-dev
+      - libssh2-1-dev
+      - psmisc
   retries: 60
   delay: 10
   register: result
@@ -66,7 +72,7 @@
   git:
     repo: "{{ repo }}"
     version: "{{ version }}"
-    dest: /var/lib/postgresql/pgbackrest
+    dest: /tmp/pgbackrest
   vars:
     repo: "{{ lookup('env', 'COMPONENT_REPO') }}"
     version: "{{ lookup('env', 'COMPONENT_VERSION') }}"
@@ -82,13 +88,18 @@
     name: postgresql
     state: stopped
 
+- name: Make sure tcp port 80 is free
+  become: true
+  command: sudo fuser -k 80/tcp
+  ignore_errors: true
+
 - name: Run pgbackrest regression
   become_user: postgres
-  command: pgbackrest/test/test.pl --psql-bin=/usr/lib/postgresql/15/bin \
+  command: pgbackrest/test/test.pl --psql-bin=/usr/lib/postgresql/14/bin \
     --no-valgrind --log-level-test-file=off --no-coverage-report \
-    --module=command --module=storage --vm-out --vm=none --no-coverage
+    --module=command --module=storage --vm-out --vm=none --no-coverage --test-path /tmp
   args:
-    chdir: "/var/lib/postgresql"
+    chdir: "/tmp"
   register: results
 
 - debug:

--- a/ppg/pg-11-meta-ha/molecule/debian-11/molecule.yml
+++ b/ppg/pg-11-meta-ha/molecule/debian-11/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
     create: ../../../../playbooks/create.yml
     destroy: ../../../../playbooks/destroy.yml
     prepare: ../../../../playbooks/prepare.yml
-    cleanup: ../../playbooks/cleanup.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
     converge: ../../playbooks/playbook.yml
 verifier:
   name: testinfra

--- a/ppg/pg-11-meta-ha/molecule/debian-12/molecule.yml
+++ b/ppg/pg-11-meta-ha/molecule/debian-12/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_ha
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  name: debian-12
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-11-meta-ha/playbooks/cleanup-deb.yml
+++ b/ppg/pg-11-meta-ha/playbooks/cleanup-deb.yml
@@ -12,6 +12,4 @@
         packages:
           - percona-postgresql-11
           - percona-patroni
-          - etcd
-          - haproxy
       when: ansible_distribution == "Debian"

--- a/ppg/pg-11-meta-server/molecule/debian-11/molecule.yml
+++ b/ppg/pg-11-meta-server/molecule/debian-11/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
     create: ../../../../playbooks/create.yml
     destroy: ../../../../playbooks/destroy.yml
     prepare: ../../../../playbooks/prepare.yml
-    cleanup: ../../playbooks/cleanup.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
     converge: ../../playbooks/playbook.yml
 verifier:
   name: testinfra

--- a/ppg/pg-11-meta-server/molecule/debian-12/molecule.yml
+++ b/ppg/pg-11-meta-server/molecule/debian-12/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  name: debian-12
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-11-minor-upgrade/molecule/debian-12/molecule.yml
+++ b/ppg/pg-11-minor-upgrade/molecule/debian-12/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg/
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-11-minor-upgrade/tasks/main.yml
+++ b/ppg/pg-11-minor-upgrade/tasks/main.yml
@@ -14,6 +14,12 @@
    ansible_distribution_major_version == "9" and
    pg_version_to_install | string is version('11.18', '<=', strict=True)
 
+- name: End play on Debian 12
+  meta: end_play
+  when: ansible_os_family == "Debian" and
+   ansible_distribution_major_version == "12" and
+   pg_version_to_install | string is version('11.20', '<=', strict=True)
+
 - name: Setup initial (old) repository
   command: percona-release enable {{ pg_version }} {{ repo }}
   vars:

--- a/ppg/pg-11/molecule/debian-10/molecule.yml
+++ b/ppg/pg-11/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0b0feb0b7d24e609b
+    image: ami-0d8e1b631d66a4b37
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-11/molecule/debian-11/molecule.yml
+++ b/ppg/pg-11/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0b2bcb9cb754576f2
+    image: ami-0205842c2a2738b72
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-11/molecule/debian-12/molecule.yml
+++ b/ppg/pg-11/molecule/debian-12/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  name: debian-12
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-12-major-upgrade/molecule/debian-12/molecule.yml
+++ b/ppg/pg-12-major-upgrade/molecule/debian-12/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg/
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-12-major-upgrade/tasks/main.yml
+++ b/ppg/pg-12-major-upgrade/tasks/main.yml
@@ -14,6 +14,12 @@
    ansible_distribution_major_version == "9" and
    pg_version_to_install | string is version('11.18', '<=', strict=True)
 
+- name: End play on Debian 12
+  meta: end_play
+  when: ansible_os_family == "Debian" and
+   ansible_distribution_major_version == "12" and
+   pg_version_to_install | string is version('11.20', '<=', strict=True)
+
 - name: Setup initial (old) repository
   command: percona-release enable {{ pg_version }} {{ repo }}
   vars:

--- a/ppg/pg-12-meta-ha/molecule/debian-11/molecule.yml
+++ b/ppg/pg-12-meta-ha/molecule/debian-11/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
     create: ../../../../playbooks/create.yml
     destroy: ../../../../playbooks/destroy.yml
     prepare: ../../../../playbooks/prepare.yml
-    cleanup: ../../playbooks/cleanup.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
     converge: ../../playbooks/playbook.yml
 verifier:
   name: testinfra

--- a/ppg/pg-12-meta-ha/molecule/debian-12/molecule.yml
+++ b/ppg/pg-12-meta-ha/molecule/debian-12/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_ha
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  name: debian-12
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-12-meta-ha/playbooks/cleanup-deb.yml
+++ b/ppg/pg-12-meta-ha/playbooks/cleanup-deb.yml
@@ -12,6 +12,4 @@
         packages:
           - percona-postgresql-12
           - percona-patroni
-          - etcd
-          - haproxy
       when: ansible_distribution == "Debian"

--- a/ppg/pg-12-meta-server/molecule/debian-11/molecule.yml
+++ b/ppg/pg-12-meta-server/molecule/debian-11/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
     create: ../../../../playbooks/create.yml
     destroy: ../../../../playbooks/destroy.yml
     prepare: ../../../../playbooks/prepare.yml
-    cleanup: ../../playbooks/cleanup.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
     converge: ../../playbooks/playbook.yml
 verifier:
   name: testinfra

--- a/ppg/pg-12-meta-server/molecule/debian-12/molecule.yml
+++ b/ppg/pg-12-meta-server/molecule/debian-12/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  name: debian-12
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-12-minor-upgrade/molecule/debian-12/molecule.yml
+++ b/ppg/pg-12-minor-upgrade/molecule/debian-12/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg/
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-12-minor-upgrade/tasks/main.yml
+++ b/ppg/pg-12-minor-upgrade/tasks/main.yml
@@ -14,6 +14,12 @@
    ansible_distribution_major_version == "9" and
    pg_version_to_install | string is version('12.13', '<=', strict=True)
 
+- name: End play on Debian 12
+  meta: end_play
+  when: ansible_os_family == "Debian" and
+   ansible_distribution_major_version == "12" and
+   pg_version_to_install | string is version('12.15', '<=', strict=True)
+
 - name: Setup initial (old) repository
   command: percona-release enable {{ pg_version }} {{ repo }}
   vars:

--- a/ppg/pg-12/molecule/debian-10/molecule.yml
+++ b/ppg/pg-12/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0b0feb0b7d24e609b
+    image: ami-0d8e1b631d66a4b37
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-12/molecule/debian-11/molecule.yml
+++ b/ppg/pg-12/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0b2bcb9cb754576f2
+    image: ami-0205842c2a2738b72
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-12/molecule/debian-12/molecule.yml
+++ b/ppg/pg-12/molecule/debian-12/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  name: debian-12
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-13-major-upgrade/molecule/debian-12/molecule.yml
+++ b/ppg/pg-13-major-upgrade/molecule/debian-12/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg/
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-13-major-upgrade/tasks/main.yml
+++ b/ppg/pg-13-major-upgrade/tasks/main.yml
@@ -14,6 +14,12 @@
    ansible_distribution_major_version == "9" and
    pg_version_to_install | string is version('12.13', '<=', strict=True)
 
+- name: End play on Debian 12
+  meta: end_play
+  when: ansible_os_family == "Debian" and
+   ansible_distribution_major_version == "12" and
+   pg_version_to_install | string is version('12.15', '<=', strict=True)
+
 - name: Setup initial (old) repository
   command: percona-release enable {{ pg_version }} {{ repo }}
   vars:

--- a/ppg/pg-13-meta-ha/molecule/debian-11/molecule.yml
+++ b/ppg/pg-13-meta-ha/molecule/debian-11/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
     create: ../../../../playbooks/create.yml
     destroy: ../../../../playbooks/destroy.yml
     prepare: ../../../../playbooks/prepare.yml
-    cleanup: ../../playbooks/cleanup.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
     converge: ../../playbooks/playbook.yml
 verifier:
   name: testinfra

--- a/ppg/pg-13-meta-ha/molecule/debian-12/molecule.yml
+++ b/ppg/pg-13-meta-ha/molecule/debian-12/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_ha
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  name: debian-12
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-13-meta-ha/playbooks/cleanup-deb.yml
+++ b/ppg/pg-13-meta-ha/playbooks/cleanup-deb.yml
@@ -12,6 +12,4 @@
         packages:
           - percona-postgresql-13
           - percona-patroni
-          - etcd
-          - haproxy
       when: ansible_distribution == "Debian"

--- a/ppg/pg-13-meta-server/molecule/debian-11/molecule.yml
+++ b/ppg/pg-13-meta-server/molecule/debian-11/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
     create: ../../../../playbooks/create.yml
     destroy: ../../../../playbooks/destroy.yml
     prepare: ../../../../playbooks/prepare.yml
-    cleanup: ../../playbooks/cleanup.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
     converge: ../../playbooks/playbook.yml
 verifier:
   name: testinfra

--- a/ppg/pg-13-meta-server/molecule/debian-12/molecule.yml
+++ b/ppg/pg-13-meta-server/molecule/debian-12/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  name: debian-12
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-13-minor-upgrade/molecule/debian-12/molecule.yml
+++ b/ppg/pg-13-minor-upgrade/molecule/debian-12/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg/
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-13-minor-upgrade/tasks/main.yml
+++ b/ppg/pg-13-minor-upgrade/tasks/main.yml
@@ -12,6 +12,12 @@
    ansible_distribution_major_version == "9" and
    pg_version_to_install | string is version('13.9', '<=', strict=True)
 
+- name: End play on Debian 12
+  meta: end_play
+  when: ansible_os_family == "Debian" and
+   ansible_distribution_major_version == "12" and
+   pg_version_to_install | string is version('13.11', '<=', strict=True)
+
 - name: Setup initial (old) repository
   command: percona-release enable {{ pg_version }} {{ repo }}
   vars:

--- a/ppg/pg-13/molecule/debian-10/molecule.yml
+++ b/ppg/pg-13/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0b0feb0b7d24e609b
+    image: ami-0d8e1b631d66a4b37
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-13/molecule/debian-11/molecule.yml
+++ b/ppg/pg-13/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0b2bcb9cb754576f2
+    image: ami-0205842c2a2738b72
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-13/molecule/debian-12/molecule.yml
+++ b/ppg/pg-13/molecule/debian-12/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  name: debian-12
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-14-major-upgrade/molecule/debian-12/molecule.yml
+++ b/ppg/pg-14-major-upgrade/molecule/debian-12/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg/
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-14-major-upgrade/tasks/main.yml
+++ b/ppg/pg-14-major-upgrade/tasks/main.yml
@@ -21,6 +21,12 @@
    ansible_distribution_major_version == "9" and
    pg_version_to_install | string is version('13.9', '<=', strict=True)
 
+- name: End play on Debian 12
+  meta: end_play
+  when: ansible_os_family == "Debian" and
+   ansible_distribution_major_version == "12" and
+   pg_version_to_install | string is version('13.11', '<=', strict=True)
+
 - name: Setup initial (old) repository
   command: percona-release enable {{ pg_version }} {{ repo }}
   vars:

--- a/ppg/pg-14-meta-ha/molecule/debian-11/molecule.yml
+++ b/ppg/pg-14-meta-ha/molecule/debian-11/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
     create: ../../../../playbooks/create.yml
     destroy: ../../../../playbooks/destroy.yml
     prepare: ../../../../playbooks/prepare.yml
-    cleanup: ../../playbooks/cleanup.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
     converge: ../../playbooks/playbook.yml
 verifier:
   name: testinfra

--- a/ppg/pg-14-meta-ha/molecule/debian-12/molecule.yml
+++ b/ppg/pg-14-meta-ha/molecule/debian-12/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_ha
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  name: debian-12
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-14-meta-ha/playbooks/cleanup-deb.yml
+++ b/ppg/pg-14-meta-ha/playbooks/cleanup-deb.yml
@@ -12,6 +12,4 @@
         packages:
           - percona-postgresql-14
           - percona-patroni
-          - etcd
-          - haproxy
       when: ansible_distribution == "Debian"

--- a/ppg/pg-14-meta-server/molecule/debian-11/molecule.yml
+++ b/ppg/pg-14-meta-server/molecule/debian-11/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
     create: ../../../../playbooks/create.yml
     destroy: ../../../../playbooks/destroy.yml
     prepare: ../../../../playbooks/prepare.yml
-    cleanup: ../../playbooks/cleanup.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
     converge: ../../playbooks/playbook.yml
 verifier:
   name: testinfra

--- a/ppg/pg-14-meta-server/molecule/debian-12/molecule.yml
+++ b/ppg/pg-14-meta-server/molecule/debian-12/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-deb.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  name: debian-12
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-14-minor-upgrade/molecule/debian-12/molecule.yml
+++ b/ppg/pg-14-minor-upgrade/molecule/debian-12/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg/
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-14-minor-upgrade/tasks/main.yml
+++ b/ppg/pg-14-minor-upgrade/tasks/main.yml
@@ -12,6 +12,12 @@
    ansible_distribution_major_version == "9" and
    pg_version_to_install | string is version('14.6', '<=', strict=True)
 
+- name: End play on Debian 12
+  meta: end_play
+  when: ansible_os_family == "Debian" and
+   ansible_distribution_major_version == "12" and
+   pg_version_to_install | string is version('14.8', '<=', strict=True)
+
 - name: Setup initial (old) repository
   command: percona-release enable {{ pg_version }} {{ repo }}
   vars:

--- a/ppg/pg-14/molecule/debian-10/molecule.yml
+++ b/ppg/pg-14/molecule/debian-10/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0b0feb0b7d24e609b
+    image: ami-0d8e1b631d66a4b37
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-14/molecule/debian-11/molecule.yml
+++ b/ppg/pg-14/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
-    image: ami-0b2bcb9cb754576f2
+    image: ami-0205842c2a2738b72
     vpc_subnet_id: subnet-085deaca8c1c59a4f
     instance_type: t2.small
     ssh_user: admin

--- a/ppg/pg-14/molecule/debian-12/molecule.yml
+++ b/ppg/pg-14/molecule/debian-12/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  name: debian-12
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-15-major-upgrade/molecule/debian-12/molecule.yml
+++ b/ppg/pg-15-major-upgrade/molecule/debian-12/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg/
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-15-major-upgrade/tasks/main.yml
+++ b/ppg/pg-15-major-upgrade/tasks/main.yml
@@ -21,6 +21,12 @@
    ansible_distribution_major_version == "9" and
    pg_version_to_install | string is version('14.6', '<=', strict=True)
 
+- name: End play on Debian 12
+  meta: end_play
+  when: ansible_os_family == "Debian" and
+   ansible_distribution_major_version == "12" and
+   pg_version_to_install | string is version('14.8', '<=', strict=True)
+
 - name: Setup initial (old) repository
   command: percona-release enable {{ pg_version }} {{ repo }}
   vars:

--- a/ppg/pg-15-minor-upgrade/molecule/debian-12/molecule.yml
+++ b/ppg/pg-15-minor-upgrade/molecule/debian-12/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
+    region: eu-central-1
+    image: ami-05e2f78cbc7f80978
+    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    instance_type: t2.small
+    ssh_user: admin
+    root_device_name: /dev/xvda
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg/
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-15-minor-upgrade/tasks/main.yml
+++ b/ppg/pg-15-minor-upgrade/tasks/main.yml
@@ -12,6 +12,12 @@
    ansible_distribution_major_version == "9" and
    pg_version_to_install | string is version('15.1', '<=', strict=True)
 
+- name: End play on Debian 12
+  meta: end_play
+  when: ansible_os_family == "Debian" and
+   ansible_distribution_major_version == "12" and
+   pg_version_to_install | string is version('15.3', '<=', strict=True)
+
 - name: Setup initial (old) repository
   command: percona-release enable {{ pg_version }} {{ repo }}
   vars:

--- a/ppg/tests/tests_ppg/test_bvt.py
+++ b/ppg/tests/tests_ppg/test_bvt.py
@@ -16,7 +16,7 @@ LANGUAGES = pg_versions['languages']
 DEB_FILES = pg_versions['deb_files']
 SKIPPED_DEBIAN = ["ppg-11.8", "ppg-11.9", "ppg-11.10", "ppg-11.12", "ppg-11.17", 'ppg-12.2',
                   'ppg-12.3', "ppg-12.4", "ppg-12.5", "ppg-12.6", "ppg-12.7", "ppg-12.12", "ppg-12.13",
-                  "ppg-12.14","ppg-12.15",
+                  "ppg-12.14", "ppg-12.15", "ppg-12.16",
                   "ppg-13.0", "ppg-13.1",
                   "ppg-15.0", "ppg-15.1"]
 BINARIES = pg_versions['binaries']

--- a/tasks/install_ppg11_tools.yml
+++ b/tasks/install_ppg11_tools.yml
@@ -204,6 +204,25 @@
         - percona-postgresql-11-wal2json-dbgsym
     when: ansible_os_family == "Debian"
 
+  - name: Install percona-pg_gather RHEL
+    yum:
+      name: percona-pg_gather
+      state: latest
+      update_cache: yes
+    when: (ansible_os_family == "RedHat" and pg_version_to_install is not defined) or
+     (ansible_os_family == "RedHat" and pg_version_to_install | string is version('11.21', '>=', strict=True))
+
+  - name: Install percona-pg_gather Debian
+    apt:
+      name: "{{ packages }}"
+      state: latest
+      update_cache: yes
+    vars:
+      packages:
+        - percona-pg-gather
+    when: (ansible_os_family == "Debian" and pg_version_to_install is not defined) or
+      (ansible_os_family == "Debian" and pg_version_to_install | string is version('11.21', '>=', strict=True))
+
   - name: Add extensions to postgresql.conf for Debian
     lineinfile:
       path: /etc/postgresql/11/main/postgresql.conf
@@ -468,7 +487,20 @@
       packages:
         - etcd
         - percona-haproxy
-    when: ansible_os_family == "Debian"
+    when: (ansible_distribution == "Ubuntu") or
+      (ansible_os_family == "Debian" and ansible_lsb.major_release|int <= 11)
+
+  - name: Install patroni related packages Debian 12
+    apt:
+      name: "{{ packages }}"
+      state: latest
+      update_cache: yes
+    vars:
+      packages:
+        - etcd-server
+        - etcd-client
+        - percona-haproxy
+    when: (ansible_os_family == "Debian" and ansible_lsb.major_release|int == 12)
 
   - name: Create /etc/patroni directory
     file:
@@ -544,6 +576,21 @@
       group: postgres
       mode: 0644
     when: ansible_os_family == "RedHat"
+
+  - name: Find all of the patroni files inside /var/lib/postgresql/patroni_test directory
+    find:
+      paths: "/var/lib/postgresql/patroni_test/"
+      patterns: "*.yml"
+    register: ymls
+    when: (ansible_os_family == "Debian" and ansible_lsb.major_release|int == 12)
+
+  - name: replace 'etcd' to 'etcd3' in /var/lib/postgresql/patroni_test/*.yml files
+    replace:
+      path: "{{ item.path }}"
+      regexp: 'etcd'
+      replace: 'etcd3'
+    with_items: "{{ ymls.files }}"
+    when: (ansible_os_family == "Debian" and ansible_lsb.major_release|int == 12)
 
   - name: Copy patroni0 service file Debian
     copy:

--- a/tasks/install_ppg12_tools.yml
+++ b/tasks/install_ppg12_tools.yml
@@ -404,6 +404,25 @@
         - percona-postgresql-12-wal2json-dbgsym
     when: ansible_os_family == "Debian"
 
+  - name: Install percona-pg_gather RHEL
+    yum:
+      name: percona-pg_gather
+      state: latest
+      update_cache: yes
+    when: (ansible_os_family == "RedHat" and pg_version_to_install is not defined) or
+     (ansible_os_family == "RedHat" and pg_version_to_install | string is version('12.16', '>=', strict=True))
+
+  - name: Install percona-pg_gather Debian
+    apt:
+      name: "{{ packages }}"
+      state: latest
+      update_cache: yes
+    vars:
+      packages:
+        - percona-pg-gather
+    when: (ansible_os_family == "Debian" and pg_version_to_install is not defined) or
+      (ansible_os_family == "Debian" and pg_version_to_install | string is version('12.16', '>=', strict=True))
+
   - name: Add extensions to postgresql.conf for Debian
     lineinfile:
       path: /etc/postgresql/12/main/postgresql.conf
@@ -519,7 +538,20 @@
       packages:
         - etcd
         - percona-haproxy
-    when: ansible_os_family == "Debian"
+    when: (ansible_distribution == "Ubuntu") or
+      (ansible_os_family == "Debian" and ansible_lsb.major_release|int <= 11)
+
+  - name: Install patroni related packages Debian 12
+    apt:
+      name: "{{ packages }}"
+      state: latest
+      update_cache: yes
+    vars:
+      packages:
+        - etcd-server
+        - etcd-client
+        - percona-haproxy
+    when: (ansible_os_family == "Debian" and ansible_lsb.major_release|int == 12)
 
   - name: Create /etc/patroni directory
     file:
@@ -595,6 +627,21 @@
       group: postgres
       mode: 0644
     when: ansible_os_family == "RedHat"
+
+  - name: Find all of the patroni files inside /var/lib/postgresql/patroni_test directory
+    find:
+      paths: "/var/lib/postgresql/patroni_test/"
+      patterns: "*.yml"
+    register: ymls
+    when: (ansible_os_family == "Debian" and ansible_lsb.major_release|int == 12)
+
+  - name: replace 'etcd' to 'etcd3' in /var/lib/postgresql/patroni_test/*.yml files
+    replace:
+      path: "{{ item.path }}"
+      regexp: 'etcd'
+      replace: 'etcd3'
+    with_items: "{{ ymls.files }}"
+    when: (ansible_os_family == "Debian" and ansible_lsb.major_release|int == 12)
 
   - name: Copy patroni0 service file Debian
     copy:

--- a/tasks/install_ppg13_tools.yml
+++ b/tasks/install_ppg13_tools.yml
@@ -408,17 +408,25 @@
         - percona-postgresql-13-wal2json-dbgsym
     when: ansible_os_family == "Debian"
 
-#  - name: Add extensions to postgresql.conf for Debian
-#    lineinfile:
-#      path: /etc/postgresql/13/main/postgresql.conf
-#      line: shared_preload_libraries = 'pgaudit, set_user'
-#    when: ansible_os_family == "Debian"
-#
-#  - name: Add extensions to postgresql.conf for RHEL
-#    lineinfile:
-#      path: /var/lib/pgsql/13/data/postgresql.conf
-#      line: shared_preload_libraries = 'pgaudit, set_user'
-#    when: ansible_os_family == "RedHat"
+  - name: Install percona-pg_gather RHEL
+    yum:
+      name: percona-pg_gather
+      state: latest
+      update_cache: yes
+    when: (ansible_os_family == "RedHat" and pg_version_to_install is not defined) or
+     (ansible_os_family == "RedHat" and pg_version_to_install | string is version('13.12', '>=', strict=True))
+
+  - name: Install percona-pg_gather Debian
+    apt:
+      name: "{{ packages }}"
+      state: latest
+      update_cache: yes
+    vars:
+      packages:
+        - percona-pg-gather
+    when: (ansible_os_family == "Debian" and pg_version_to_install is not defined) or
+      (ansible_os_family == "Debian" and pg_version_to_install | string is version('13.12', '>=', strict=True))
+
   - name: Add extensions to postgresql.conf for Debian
     lineinfile:
       path: /etc/postgresql/13/main/postgresql.conf
@@ -518,7 +526,20 @@
       packages:
         - etcd
         - percona-haproxy
-    when: ansible_os_family == "Debian"
+    when: (ansible_distribution == "Ubuntu") or
+      (ansible_os_family == "Debian" and ansible_lsb.major_release|int <= 11)
+
+  - name: Install patroni related packages Debian 12
+    apt:
+      name: "{{ packages }}"
+      state: latest
+      update_cache: yes
+    vars:
+      packages:
+        - etcd-server
+        - etcd-client
+        - percona-haproxy
+    when: (ansible_os_family == "Debian" and ansible_lsb.major_release|int == 12)
 
   - name: Create /etc/patroni directory
     file:
@@ -594,6 +615,21 @@
       group: postgres
       mode: 0644
     when: ansible_os_family == "RedHat"
+
+  - name: Find all of the patroni files inside /var/lib/postgresql/patroni_test directory
+    find:
+      paths: "/var/lib/postgresql/patroni_test/"
+      patterns: "*.yml"
+    register: ymls
+    when: (ansible_os_family == "Debian" and ansible_lsb.major_release|int == 12)
+
+  - name: replace 'etcd' to 'etcd3' in /var/lib/postgresql/patroni_test/*.yml files
+    replace:
+      path: "{{ item.path }}"
+      regexp: 'etcd'
+      replace: 'etcd3'
+    with_items: "{{ ymls.files }}"
+    when: (ansible_os_family == "Debian" and ansible_lsb.major_release|int == 12)
 
   - name: Copy patroni0 service file Debian
     copy:

--- a/tasks/install_ppg14_tools.yml
+++ b/tasks/install_ppg14_tools.yml
@@ -398,6 +398,25 @@
         - percona-postgresql-14-wal2json-dbgsym
     when: ansible_os_family == "Debian"
 
+  - name: Install percona-pg_gather RHEL
+    yum:
+      name: percona-pg_gather
+      state: latest
+      update_cache: yes
+    when: (ansible_os_family == "RedHat" and pg_version_to_install is not defined) or
+     (ansible_os_family == "RedHat" and pg_version_to_install | string is version('14.9', '>=', strict=True))
+
+  - name: Install percona-pg_gather Debian
+    apt:
+      name: "{{ packages }}"
+      state: latest
+      update_cache: yes
+    vars:
+      packages:
+        - percona-pg-gather
+    when: (ansible_os_family == "Debian" and pg_version_to_install is not defined) or
+      (ansible_os_family == "Debian" and pg_version_to_install | string is version('14.9', '>=', strict=True))
+
   - name: Add extensions to postgresql.conf for Debian
     lineinfile:
       path: /etc/postgresql/14/main/postgresql.conf
@@ -497,7 +516,20 @@
       packages:
         - etcd
         - percona-haproxy
-    when: ansible_os_family == "Debian"
+    when: (ansible_distribution == "Ubuntu") or
+      (ansible_os_family == "Debian" and ansible_lsb.major_release|int <= 11)
+
+  - name: Install patroni related packages Debian 12
+    apt:
+      name: "{{ packages }}"
+      state: latest
+      update_cache: yes
+    vars:
+      packages:
+        - etcd-server
+        - etcd-client
+        - percona-haproxy
+    when: (ansible_os_family == "Debian" and ansible_lsb.major_release|int == 12)
 
   - name: Create /etc/patroni directory
     file:
@@ -573,6 +605,21 @@
       group: postgres
       mode: 0644
     when: ansible_os_family == "RedHat"
+
+  - name: Find all of the patroni files inside /var/lib/postgresql/patroni_test directory
+    find:
+      paths: "/var/lib/postgresql/patroni_test/"
+      patterns: "*.yml"
+    register: ymls
+    when: (ansible_os_family == "Debian" and ansible_lsb.major_release|int == 12)
+
+  - name: replace 'etcd' to 'etcd3' in /var/lib/postgresql/patroni_test/*.yml files
+    replace:
+      path: "{{ item.path }}"
+      regexp: 'etcd'
+      replace: 'etcd3'
+    with_items: "{{ ymls.files }}"
+    when: (ansible_os_family == "Debian" and ansible_lsb.major_release|int == 12)
 
   - name: Copy patroni0 service file Debian
     copy:

--- a/tasks/install_ppg15_tools.yml
+++ b/tasks/install_ppg15_tools.yml
@@ -391,7 +391,8 @@
       name: percona-pg_gather
       state: latest
       update_cache: yes
-    when: ansible_os_family == "RedHat"
+    when: (ansible_os_family == "RedHat" and pg_version_to_install is not defined) or
+     (ansible_os_family == "RedHat" and pg_version_to_install | string is version('15.4', '>=', strict=True))
 
   - name: Install percona-pg_gather Debian
     apt:
@@ -401,7 +402,8 @@
     vars:
       packages:
         - percona-pg-gather
-    when: ansible_os_family == "Debian"
+    when: (ansible_os_family == "Debian" and pg_version_to_install is not defined) or
+      (ansible_os_family == "Debian" and pg_version_to_install | string is version('15.4', '>=', strict=True))
 
   - name: Add extensions to postgresql.conf for Debian
     lineinfile:


### PR DESCRIPTION
1. Moved PGSM VM from t2.medium to t2.xlarge for ppg-11~15.
2. Added bookwork (debian-12) to debian distros.
3. Adding debian-12 to ppg-11~14. Updated ami-vm for debian 10 & 11.
4. Fix patroni component tests failure for ppg-11~14.
5. Fix patroni test failure on debian-12 for ppg-11~14.
6. Fix pgbackrest component failures ppg-11~14.
7. Added pg_gather v22 product and testcase for ppg-11~14.
8. Adding debian-12 to meta-ha and meta-server ppg-11~14 testing. Also fixed clean up of packages for debian-11.
9. Fixed meta-ha failing testcase for etcd on ppg-11~14.
10. Moved pgbackrest VM from t2.medium to t2.xlarge for ppg-11~15.
11. Updating ppg-15 where pg_gather will not be installed for any ppg-15 version before 15.4. 15.4 is first time we are releasing pg_gather.
12. Adding Debian-12 to ppg-15 minor and major upgrade.
13. Making sure pg_gather is installed only on and onwards where these packages were made available, ppg 15.4, 14.9, 13.12, 12.16, 11.21.
14. Fixed ppg-11~15 upgrade.
15. Added plythonu and plpython2u to be skipped on ppg 12.16.
16. Added Debian-12 to minor and major update scenario for ppg-11~14.