### PR TITLE
Do not add `-<arch>` suffix to image tag in ppg-docker-custom scenario

### DIFF
--- a/docker/ppg-docker-custom/tasks/main.yml
+++ b/docker/ppg-docker-custom/tasks/main.yml
@@ -12,17 +12,6 @@
   debug:
     msg: "WITH_POSTGIS: {{ WITH_POSTGIS }}"
 
-- name: Assign TAG based on architecture and version
-  set_fact:
-    TAG: >-
-      {{
-        TAG if ansible_architecture == 'x86_64' and not TAG|regex_search('multi')
-        else TAG if ansible_architecture == 'aarch64' and (not TAG|regex_search('multi') and TAG|regex_search('-arm64$'))
-        else TAG|string + '-arm64' if ansible_architecture == 'aarch64' and not TAG|regex_search('multi')
-        else TAG
-      }}
-  when: "ansible_architecture == 'x86_64' or ansible_architecture == 'aarch64'"
-
 - name: Print PPG_VERSION and TAG
   debug:
     msg: "PPG_VERSION: {{ PPG_VERSION }}, TAG: {{ TAG }}"


### PR DESCRIPTION
The container images generated in OBS do not contain tags with the `-$(ARCH)` suffix and therefore the `ppg-docker-custom` molecule scenario fails because it tries to use an image with tag `TAG-arm64` when testing in an aarch64 system.

This PR removes the step that adds the `-arm64` suffix since it's not needed as docker will pull the image corresponding to the architecture of the host OS.