### PR TITLE
PG-2353: Add Oracle Linux 10 molecule scenarios (x86_64 + arm64)

### DIFF
--- a/pg_stat_monitor/pgsm/molecule/ol-10-arm/molecule.yml
+++ b/pg_stat_monitor/pgsm/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: pgstatmon-ol10-arm-${BUILD_NUMBER}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: ansible
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - destroy

--- a/pg_stat_monitor/pgsm/molecule/ol-10/molecule.yml
+++ b/pg_stat_monitor/pgsm/molecule/ol-10/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: pgstatmon-ol10-${BUILD_NUMBER}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: ansible
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - destroy

--- a/pg_stat_monitor/pgsm_pgdg/molecule/ol-10-arm/molecule.yml
+++ b/pg_stat_monitor/pgsm_pgdg/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: pgstatmon-ol10-arm-${BUILD_NUMBER}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: ansible
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - destroy

--- a/pg_stat_monitor/pgsm_pgdg/molecule/ol-10/molecule.yml
+++ b/pg_stat_monitor/pgsm_pgdg/molecule/ol-10/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: pgstatmon-ol10-${BUILD_NUMBER}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: ansible
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - destroy

--- a/pg_tde/auxiliary/molecule/ol-10-arm/molecule.yml
+++ b/pg_tde/auxiliary/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: tde-auxiliary-ol10-arm-${BUILD_NUMBER}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t4g.2xlarge
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: ansible
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - destroy

--- a/pg_tde/auxiliary/molecule/ol-10/molecule.yml
+++ b/pg_tde/auxiliary/molecule/ol-10/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: tde-auxiliary-ol10-${BUILD_NUMBER}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t3.2xlarge
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: ansible
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - destroy

--- a/pg_tde/tde/molecule/ol-10-arm/molecule.yml
+++ b/pg_tde/tde/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: pgtde-ol10-arm-${BUILD_NUMBER}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t4g.xlarge
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: ansible
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - destroy

--- a/pg_tde/tde/molecule/ol-10/molecule.yml
+++ b/pg_tde/tde/molecule/ol-10/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: pgtde-ol10-${BUILD_NUMBER}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t3.xlarge
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: ansible
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - destroy

--- a/ppg/pg-14-major-upgrade/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-14-major-upgrade/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+    cleanup: ../../playbooks/cleanup.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-14-major-upgrade/molecule/ol-10/molecule.yml
+++ b/ppg/pg-14-major-upgrade/molecule/ol-10/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+    cleanup: ../../playbooks/cleanup.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-14-meta-ha/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-14-meta-ha/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_ha
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-14-meta-ha/molecule/ol-10/molecule.yml
+++ b/ppg/pg-14-meta-ha/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_ha
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-14-meta-server/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-14-meta-server/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-14-meta-server/molecule/ol-10/molecule.yml
+++ b/ppg/pg-14-meta-server/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-14-minor-upgrade/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-14-minor-upgrade/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-14-minor-upgrade/molecule/ol-10/molecule.yml
+++ b/ppg/pg-14-minor-upgrade/molecule/ol-10/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-14/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-14/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-14/molecule/ol-10/molecule.yml
+++ b/ppg/pg-14/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-15-major-upgrade/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-15-major-upgrade/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+    cleanup: ../../playbooks/cleanup.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-15-major-upgrade/molecule/ol-10/molecule.yml
+++ b/ppg/pg-15-major-upgrade/molecule/ol-10/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+    cleanup: ../../playbooks/cleanup.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-15-meta-ha/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-15-meta-ha/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_ha
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-15-meta-ha/molecule/ol-10/molecule.yml
+++ b/ppg/pg-15-meta-ha/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_ha
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-15-meta-server/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-15-meta-server/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-15-meta-server/molecule/ol-10/molecule.yml
+++ b/ppg/pg-15-meta-server/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-15-minor-upgrade/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-15-minor-upgrade/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-15-minor-upgrade/molecule/ol-10/molecule.yml
+++ b/ppg/pg-15-minor-upgrade/molecule/ol-10/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-15/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-15/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-15/molecule/ol-10/molecule.yml
+++ b/ppg/pg-15/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-16-major-upgrade/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-16-major-upgrade/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+    cleanup: ../../playbooks/cleanup.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-16-major-upgrade/molecule/ol-10/molecule.yml
+++ b/ppg/pg-16-major-upgrade/molecule/ol-10/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+    cleanup: ../../playbooks/cleanup.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-16-meta-ha/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-16-meta-ha/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_ha
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-16-meta-ha/molecule/ol-10/molecule.yml
+++ b/ppg/pg-16-meta-ha/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_ha
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-16-meta-server/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-16-meta-server/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-16-meta-server/molecule/ol-10/molecule.yml
+++ b/ppg/pg-16-meta-server/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-16-minor-upgrade/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-16-minor-upgrade/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-16-minor-upgrade/molecule/ol-10/molecule.yml
+++ b/ppg/pg-16-minor-upgrade/molecule/ol-10/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-16/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-16/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-16/molecule/ol-10/molecule.yml
+++ b/ppg/pg-16/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-17-major-upgrade/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-17-major-upgrade/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+    cleanup: ../../playbooks/cleanup.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-17-major-upgrade/molecule/ol-10/molecule.yml
+++ b/ppg/pg-17-major-upgrade/molecule/ol-10/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+    cleanup: ../../playbooks/cleanup.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-17-meta-ha/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-17-meta-ha/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_ha
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-17-meta-ha/molecule/ol-10/molecule.yml
+++ b/ppg/pg-17-meta-ha/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_ha
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-17-meta-server/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-17-meta-server/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-17-meta-server/molecule/ol-10/molecule.yml
+++ b/ppg/pg-17-meta-server/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-17-minor-upgrade/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-17-minor-upgrade/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-17-minor-upgrade/molecule/ol-10/molecule.yml
+++ b/ppg/pg-17-minor-upgrade/molecule/ol-10/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-17/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-17/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-17/molecule/ol-10/molecule.yml
+++ b/ppg/pg-17/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-18-major-upgrade/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-18-major-upgrade/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+    cleanup: ../../playbooks/cleanup.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-18-major-upgrade/molecule/ol-10/molecule.yml
+++ b/ppg/pg-18-major-upgrade/molecule/ol-10/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+    cleanup: ../../playbooks/cleanup.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-18-meta-ha/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-18-meta-ha/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_ha
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-18-meta-ha/molecule/ol-10/molecule.yml
+++ b/ppg/pg-18-meta-ha/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_ha
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-18-meta-server/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-18-meta-server/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-18-meta-server/molecule/ol-10/molecule.yml
+++ b/ppg/pg-18-meta-server/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_meta_server
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-18-minor-upgrade/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-18-minor-upgrade/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-18-minor-upgrade/molecule/ol-10/molecule.yml
+++ b/ppg/pg-18-minor-upgrade/molecule/ol-10/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws1}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    m: upgrade
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/ppg/pg-18/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-18/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-18/molecule/ol-10/molecule.yml
+++ b/ppg/pg-18/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-tarballs/molecule/ol-10-arm/molecule.yml
+++ b/ppg/pg-tarballs/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-arm-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t4g.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg_tarballs
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/ppg/pg-tarballs/molecule/ol-10/molecule.yml
+++ b/ppg/pg-tarballs/molecule/ol-10/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: ol10-${BUILD_NUMBER}-${JOB_NAME}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t3.large
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    cleanup: ../../playbooks/cleanup-rpm.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: testinfra
+  directory: ../../../tests/tests_ppg_tarballs
+  options:
+    verbose: true
+    s: true
+    junitxml: report.xml
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/psp/performance_tests/molecule/ol-10-arm/molecule.yml
+++ b/psp/performance_tests/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: psp-ol10-arm-${BUILD_NUMBER}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t4g.xlarge
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: ansible
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - destroy

--- a/psp/performance_tests/molecule/ol-10/molecule.yml
+++ b/psp/performance_tests/molecule/ol-10/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: psp-ol10-${BUILD_NUMBER}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t3.xlarge
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: ansible
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - destroy

--- a/psp/server_tests/molecule/ol-10-arm/molecule.yml
+++ b/psp/server_tests/molecule/ol-10-arm/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: psp-ol10-arm-${BUILD_NUMBER}
+    region: ${region}
+    image: ${ami_ol10_arm64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t4g.xlarge
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: ansible
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - destroy

--- a/psp/server_tests/molecule/ol-10/molecule.yml
+++ b/psp/server_tests/molecule/ol-10/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${driver}
+platforms:
+  - name: psp-ol10-${BUILD_NUMBER}
+    region: ${region}
+    image: ${ami_ol10_x86_64}
+    vpc_subnet_id: ${vpc_subnet_id_aws2}
+    instance_type: t3.xlarge
+    ssh_user: ec2-user
+    root_device_name: /dev/sda1
+    instance_tags:
+      iit-billing-tag: jenkins-pg-worker
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    create: ../../../../playbooks/create.yml
+    destroy: ../../../../playbooks/destroy.yml
+    prepare: ../../../../playbooks/prepare.yml
+    converge: ../../playbooks/playbook.yml
+verifier:
+  name: ansible
+scenario:
+  destroy_sequence:
+    - destroy
+  cleanup_sequence:
+    - cleanup
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - destroy


### PR DESCRIPTION
**Feature**
- Add 64 Oracle Linux 10 molecule scenarios (32 suites across x86_64 + arm64) covering pg_stat_monitor, pg_tde, ppg (pg-14 to pg-18), and psp.

**Why**
- Extends PPG package testing to Oracle Linux 10, matching the new `ol-10`/`ol-10-arm` entries in the jenkins-pipelines OS lists.
- Each scenario resolves its image via `${ami_ol10_x86_64}` / `${ami_ol10_arm64}`, the AMIs the new factory promotes.

**Tickets**
- [PG-2353](https://perconadev.atlassian.net/browse/PG-2353) (this). Companion: [jenkins-pipelines#4168](https://github.com/Percona-Lab/jenkins-pipelines/pull/4168) (factory + OS lists), [cd-platform#99](https://github.com/percona/percona-cd-platform/pull/99) (OIDC role).

[PG-2353]: https://perconadev.atlassian.net/browse/PG-2353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ