### PR TITLE
PG-2353: Enable CRB on Oracle Linux 10 for molecule tests

### DIFF
--- a/playbooks/prepare.yml
+++ b/playbooks/prepare.yml
@@ -133,6 +133,13 @@
         dnf config-manager --set-enabled ol9_codeready_builder
       when: ansible_distribution == "OracleLinux" and ansible_distribution_major_version == "9"
 
+    - name: Enable ol10_codeready_builder on Oracle Linux 10
+      become: true
+      shell: |
+        dnf install -y dnf-plugins-core
+        dnf config-manager --set-enabled ol10_codeready_builder
+      when: ansible_distribution == "OracleLinux" and ansible_distribution_major_version == "10"
+
     - name: Enable codeready-builder for RHEL 8
       become: true
       shell: | 


### PR DESCRIPTION
**Bug**
- OL10 molecule `prepare` fails installing `perl-JSON-XS` / `perl-IPC-Run` (No package available), so every OL10 PPG molecule run fails. These packages live in the CodeReady Builder (CRB) repo.

**Fix**
- Add an `ol10_codeready_builder` enable task, mirroring the existing OL8 and OL9 tasks. OL10 was the only Oracle Linux major missing one.

**Tickets**
- [PG-2353](https://perconadev.atlassian.net/browse/PG-2353) (this)

[PG-2353]: https://perconadev.atlassian.net/browse/PG-2353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ