### PR TITLE
pg_tde/auxiliary: skip repo config when building from source

### DIFF
--- a/pg_tde/auxiliary/tasks/main.yml
+++ b/pg_tde/auxiliary/tasks/main.yml
@@ -2,7 +2,7 @@
   - name: Set Base Facts
     set_fact:
       major_version: "{{ lookup('env','VERSION') | regex_replace('ppg-(\\d+).*','\\1') }}"
-      install_from_packages: "{{ lookup('env', 'INSTALL_FROM_PACKAGES')}}"
+      install_from_packages: "{{ lookup('env', 'INSTALL_FROM_PACKAGES') | default('false') | bool }}"
       full_version: "{{ lookup('env','VERSION') | regex_replace('ppg-','') }}"
 
       # Convert "true"/"false" strings to actual Booleans
@@ -113,6 +113,7 @@
 
   - name: Configure repository
     ansible.builtin.include_tasks: ../../../../tasks/enable_repo.yml
+    when: install_from_packages
 
   - name: Include Redhat tasks file
     include_tasks: 


### PR DESCRIPTION
install_from_packages was stored as a raw env-var string, so a downstream `when: install_from_packages` check would be truthy even for the literal string "false". Cast it through | bool like the other flags, and gate the "Configure repository" (enable_repo.yml) task on it so source-build runs no longer enable a package repo they don't need.