### PR TITLE
pg_tde: source gcc-toolset-14 on RHEL 8 in upgrade build_tde_source.yml

### DIFF
--- a/pg_tde/upgrade/tasks/build_tde_source.yml
+++ b/pg_tde/upgrade/tasks/build_tde_source.yml
@@ -124,7 +124,7 @@
     become: true
     become_user: postgres
     shell: |
-      {% if ansible_os_family == 'RedHat' and ansible_distribution_major_version == '9' %}
+      {% if ansible_os_family == 'RedHat' and ansible_distribution_major_version in ['8', '9'] %}
       source /opt/rh/gcc-toolset-14/enable
       {% endif %}
       set -o pipefail
@@ -181,7 +181,7 @@
   - name: Build and install pg_tde via PGXS against {{ pg_config_path }}
     become: true
     shell: |
-      {% if ansible_os_family == 'RedHat' and ansible_distribution_major_version == '9' %}
+      {% if ansible_os_family == 'RedHat' and ansible_distribution_major_version in ['8', '9'] %}
       source /opt/rh/gcc-toolset-14/enable
       {% endif %}
       set -o pipefail


### PR DESCRIPTION
The Jinja2 condition gating gcc-toolset-14 activation only matched RHEL 9; RHEL/OL/Rocky 8 builds were still using GCC 8.5 which lacks <span>, causing libkmip compilation to fail. Extend the condition to cover major version 8 and 9.