### PR TITLE
PG-2603 test: verify wal_compression algorithm support (pglz/lz4/zstd)

### DIFF
--- a/docker/ppg-docker-custom-upgrade/files/test_docker.py
+++ b/docker/ppg-docker-custom-upgrade/files/test_docker.py
@@ -752,6 +752,50 @@ def test_build_with_liburing(host):
     assert "--with-liburing" in output, "PostgreSQL 18 was built without --with-liburing"
 
 
+# wal_compression algorithm -> minimum PostgreSQL major version that supports it
+WAL_COMPRESSION_ALGORITHMS = {
+    "pglz": 14,
+    "lz4": 15,
+    "zstd": 15,
+}
+
+
+@pytest.mark.parametrize("algo", list(WAL_COMPRESSION_ALGORITHMS))
+def test_wal_compression_algorithms(host, algo):
+    """
+    Verify that wal_compression accepts each algorithm expected to be
+    built into this image (pglz: PG14+, lz4/zstd: PG15+).
+    ALTER SYSTEM SET rejects the value immediately if the server wasn't
+    compiled with support for it.
+
+    wal_compression is a plain boolean GUC before PG15 (pglz is the only,
+    implicit algorithm) and only became an enum accepting the literal
+    values pglz/lz4/zstd from PG15 onward, so PG14 must be driven via the
+    boolean spelling "on" rather than the literal "pglz".
+    """
+    min_ver = WAL_COMPRESSION_ALGORITHMS[algo]
+    if int(MAJOR_VER) < min_ver:
+        pytest.skip(f"wal_compression={algo} requires PG{min_ver}+, found {MAJOR_VER}")
+
+    is_pg14_pglz = algo == "pglz" and int(MAJOR_VER) < 15
+    set_value = "on" if is_pg14_pglz else algo
+    expected = "on" if is_pg14_pglz else algo
+
+    try:
+        result = host.run(f"psql -c \"ALTER SYSTEM SET wal_compression = '{set_value}';\"")
+        assert result.rc == 0, result.stderr
+        assert "ALTER SYSTEM" in result.stdout, result.stdout
+
+        reload = host.run("psql -c 'SELECT pg_reload_conf();'")
+        assert reload.rc == 0, reload.stderr
+
+        show = host.run("psql -t -c 'SHOW wal_compression;'").stdout.strip()
+        assert show == expected, f"Expected wal_compression={expected}, got '{show}'"
+    finally:
+        host.run("psql -c 'ALTER SYSTEM RESET wal_compression;'")
+        host.run("psql -c 'SELECT pg_reload_conf();'")
+
+
 @pytest.mark.parametrize(
     "flag",
     [

--- a/docker/ppg-docker-custom/files/test_docker.py
+++ b/docker/ppg-docker-custom/files/test_docker.py
@@ -662,6 +662,50 @@ def test_build_with_liburing(host):
     assert "--with-liburing" in output, "PostgreSQL 18 was built without --with-liburing"
 
 
+# wal_compression algorithm -> minimum PostgreSQL major version that supports it
+WAL_COMPRESSION_ALGORITHMS = {
+    "pglz": 14,
+    "lz4": 15,
+    "zstd": 15,
+}
+
+
+@pytest.mark.parametrize("algo", list(WAL_COMPRESSION_ALGORITHMS))
+def test_wal_compression_algorithms(host, algo):
+    """
+    Verify that wal_compression accepts each algorithm expected to be
+    built into this image (pglz: PG14+, lz4/zstd: PG15+).
+    ALTER SYSTEM SET rejects the value immediately if the server wasn't
+    compiled with support for it.
+
+    wal_compression is a plain boolean GUC before PG15 (pglz is the only,
+    implicit algorithm) and only became an enum accepting the literal
+    values pglz/lz4/zstd from PG15 onward, so PG14 must be driven via the
+    boolean spelling "on" rather than the literal "pglz".
+    """
+    min_ver = WAL_COMPRESSION_ALGORITHMS[algo]
+    if int(MAJOR_VER) < min_ver:
+        pytest.skip(f"wal_compression={algo} requires PG{min_ver}+, found {MAJOR_VER}")
+
+    is_pg14_pglz = algo == "pglz" and int(MAJOR_VER) < 15
+    set_value = "on" if is_pg14_pglz else algo
+    expected = "on" if is_pg14_pglz else algo
+
+    try:
+        result = host.run(f"psql -c \"ALTER SYSTEM SET wal_compression = '{set_value}';\"")
+        assert result.rc == 0, result.stderr
+        assert "ALTER SYSTEM" in result.stdout, result.stdout
+
+        reload = host.run("psql -c 'SELECT pg_reload_conf();'")
+        assert reload.rc == 0, reload.stderr
+
+        show = host.run("psql -t -c 'SHOW wal_compression;'").stdout.strip()
+        assert show == expected, f"Expected wal_compression={expected}, got '{show}'"
+    finally:
+        host.run("psql -c 'ALTER SYSTEM RESET wal_compression;'")
+        host.run("psql -c 'SELECT pg_reload_conf();'")
+
+
 @pytest.mark.parametrize(
     "flag",
     [

--- a/docker/ppg-docker-upgrade/files/test_docker.py
+++ b/docker/ppg-docker-upgrade/files/test_docker.py
@@ -692,6 +692,50 @@ def test_build_with_liburing(host):
     assert "--with-liburing" in output, "PostgreSQL 18 was built without --with-liburing"
 
 
+# wal_compression algorithm -> minimum PostgreSQL major version that supports it
+WAL_COMPRESSION_ALGORITHMS = {
+    "pglz": 14,
+    "lz4": 15,
+    "zstd": 15,
+}
+
+
+@pytest.mark.parametrize("algo", list(WAL_COMPRESSION_ALGORITHMS))
+def test_wal_compression_algorithms(host, algo):
+    """
+    Verify that wal_compression accepts each algorithm expected to be
+    built into this image (pglz: PG14+, lz4/zstd: PG15+).
+    ALTER SYSTEM SET rejects the value immediately if the server wasn't
+    compiled with support for it.
+
+    wal_compression is a plain boolean GUC before PG15 (pglz is the only,
+    implicit algorithm) and only became an enum accepting the literal
+    values pglz/lz4/zstd from PG15 onward, so PG14 must be driven via the
+    boolean spelling "on" rather than the literal "pglz".
+    """
+    min_ver = WAL_COMPRESSION_ALGORITHMS[algo]
+    if int(MAJOR_VER) < min_ver:
+        pytest.skip(f"wal_compression={algo} requires PG{min_ver}+, found {MAJOR_VER}")
+
+    is_pg14_pglz = algo == "pglz" and int(MAJOR_VER) < 15
+    set_value = "on" if is_pg14_pglz else algo
+    expected = "on" if is_pg14_pglz else algo
+
+    try:
+        result = host.run(f"psql -c \"ALTER SYSTEM SET wal_compression = '{set_value}';\"")
+        assert result.rc == 0, result.stderr
+        assert "ALTER SYSTEM" in result.stdout, result.stdout
+
+        reload = host.run("psql -c 'SELECT pg_reload_conf();'")
+        assert reload.rc == 0, reload.stderr
+
+        show = host.run("psql -t -c 'SHOW wal_compression;'").stdout.strip()
+        assert show == expected, f"Expected wal_compression={expected}, got '{show}'"
+    finally:
+        host.run("psql -c 'ALTER SYSTEM RESET wal_compression;'")
+        host.run("psql -c 'SELECT pg_reload_conf();'")
+
+
 @pytest.mark.parametrize(
     "flag",
     [

--- a/docker/ppg-docker/files/test_docker.py
+++ b/docker/ppg-docker/files/test_docker.py
@@ -698,6 +698,50 @@ def test_build_with_liburing(host):
     assert "--with-liburing" in output, "PostgreSQL 18 was built without --with-liburing"
 
 
+# wal_compression algorithm -> minimum PostgreSQL major version that supports it
+WAL_COMPRESSION_ALGORITHMS = {
+    "pglz": 14,
+    "lz4": 15,
+    "zstd": 15,
+}
+
+
+@pytest.mark.parametrize("algo", list(WAL_COMPRESSION_ALGORITHMS))
+def test_wal_compression_algorithms(host, algo):
+    """
+    Verify that wal_compression accepts each algorithm expected to be
+    built into this image (pglz: PG14+, lz4/zstd: PG15+).
+    ALTER SYSTEM SET rejects the value immediately if the server wasn't
+    compiled with support for it.
+
+    wal_compression is a plain boolean GUC before PG15 (pglz is the only,
+    implicit algorithm) and only became an enum accepting the literal
+    values pglz/lz4/zstd from PG15 onward, so PG14 must be driven via the
+    boolean spelling "on" rather than the literal "pglz".
+    """
+    min_ver = WAL_COMPRESSION_ALGORITHMS[algo]
+    if int(MAJOR_VER) < min_ver:
+        pytest.skip(f"wal_compression={algo} requires PG{min_ver}+, found {MAJOR_VER}")
+
+    is_pg14_pglz = algo == "pglz" and int(MAJOR_VER) < 15
+    set_value = "on" if is_pg14_pglz else algo
+    expected = "on" if is_pg14_pglz else algo
+
+    try:
+        result = host.run(f"psql -c \"ALTER SYSTEM SET wal_compression = '{set_value}';\"")
+        assert result.rc == 0, result.stderr
+        assert "ALTER SYSTEM" in result.stdout, result.stdout
+
+        reload = host.run("psql -c 'SELECT pg_reload_conf();'")
+        assert reload.rc == 0, reload.stderr
+
+        show = host.run("psql -t -c 'SHOW wal_compression;'").stdout.strip()
+        assert show == expected, f"Expected wal_compression={expected}, got '{show}'"
+    finally:
+        host.run("psql -c 'ALTER SYSTEM RESET wal_compression;'")
+        host.run("psql -c 'SELECT pg_reload_conf();'")
+
+
 @pytest.mark.parametrize(
     "flag",
     [

--- a/ppg/tests/tests_ppg/test_bvt.py
+++ b/ppg/tests/tests_ppg/test_bvt.py
@@ -568,6 +568,51 @@ def test_build_with_liburing(host):
     assert '--with-liburing' in output, "PostgreSQL 18 was built without --with-liburing"
 
 
+# wal_compression algorithm -> minimum PostgreSQL major version that supports it
+WAL_COMPRESSION_ALGORITHMS = {
+    "pglz": 14,
+    "lz4": 15,
+    "zstd": 15,
+}
+
+
+@pytest.mark.parametrize("algo", list(WAL_COMPRESSION_ALGORITHMS))
+def test_wal_compression_algorithms(host, algo):
+    """
+    Verify that wal_compression accepts each algorithm expected to be
+    built into this distribution (pglz: PG14+, lz4/zstd: PG15+).
+    ALTER SYSTEM SET rejects the value immediately if the server wasn't
+    compiled with support for it.
+
+    wal_compression is a plain boolean GUC before PG15 (pglz is the only,
+    implicit algorithm) and only became an enum accepting the literal
+    values pglz/lz4/zstd from PG15 onward, so PG14 must be driven via the
+    boolean spelling "on" rather than the literal "pglz".
+    """
+    min_ver = WAL_COMPRESSION_ALGORITHMS[algo]
+    if int(settings.MAJOR_VER) < min_ver:
+        pytest.skip(f"wal_compression={algo} requires PG{min_ver}+, found {settings.MAJOR_VER}")
+
+    is_pg14_pglz = algo == "pglz" and int(settings.MAJOR_VER) < 15
+    set_value = "on" if is_pg14_pglz else algo
+    expected = "on" if is_pg14_pglz else algo
+
+    with host.sudo("postgres"):
+        try:
+            result = host.run(f"psql -c \"ALTER SYSTEM SET wal_compression = '{set_value}';\"")
+            assert result.rc == 0, result.stderr
+            assert "ALTER SYSTEM" in result.stdout, result.stdout
+
+            reload = host.run("psql -c 'SELECT pg_reload_conf();'")
+            assert reload.rc == 0, reload.stderr
+
+            show = host.check_output("psql -t -c 'SHOW wal_compression;'").strip()
+            assert show == expected, f"Expected wal_compression={expected}, got '{show}'"
+        finally:
+            host.run("psql -c 'ALTER SYSTEM RESET wal_compression;'")
+            host.run("psql -c 'SELECT pg_reload_conf();'")
+
+
 @pytest.mark.parametrize(
     "flag,skip_on_debian",
     [

--- a/ppg/tests/tests_ppg_tarballs/test_bvt.py
+++ b/ppg/tests/tests_ppg_tarballs/test_bvt.py
@@ -393,6 +393,51 @@ def test_build_with_liburing(host, get_server_bin_path):
     assert '--with-liburing' in output, "PostgreSQL 18 was built without --with-liburing"
 
 
+# wal_compression algorithm -> minimum PostgreSQL major version that supports it
+WAL_COMPRESSION_ALGORITHMS = {
+    "pglz": 14,
+    "lz4": 15,
+    "zstd": 15,
+}
+
+
+@pytest.mark.parametrize("algo", list(WAL_COMPRESSION_ALGORITHMS))
+def test_wal_compression_algorithms(host, get_psql_binary_path, algo):
+    """
+    Verify that wal_compression accepts each algorithm expected to be
+    built into this distribution (pglz: PG14+, lz4/zstd: PG15+).
+    ALTER SYSTEM SET rejects the value immediately if the server wasn't
+    compiled with support for it.
+
+    wal_compression is a plain boolean GUC before PG15 (pglz is the only,
+    implicit algorithm) and only became an enum accepting the literal
+    values pglz/lz4/zstd from PG15 onward, so PG14 must be driven via the
+    boolean spelling "on" rather than the literal "pglz".
+    """
+    min_ver = WAL_COMPRESSION_ALGORITHMS[algo]
+    if int(settings.MAJOR_VER) < min_ver:
+        pytest.skip(f"wal_compression={algo} requires PG{min_ver}+, found {settings.MAJOR_VER}")
+
+    is_pg14_pglz = algo == "pglz" and int(settings.MAJOR_VER) < 15
+    set_value = "on" if is_pg14_pglz else algo
+    expected = "on" if is_pg14_pglz else algo
+
+    with host.sudo("postgres"):
+        try:
+            result = host.run(f"{get_psql_binary_path} -c \"ALTER SYSTEM SET wal_compression = '{set_value}';\"")
+            assert result.rc == 0, result.stderr
+            assert "ALTER SYSTEM" in result.stdout, result.stdout
+
+            reload = host.run(f"{get_psql_binary_path} -c 'SELECT pg_reload_conf();'")
+            assert reload.rc == 0, reload.stderr
+
+            show = host.check_output(f"{get_psql_binary_path} -t -c 'SHOW wal_compression;'").strip()
+            assert show == expected, f"Expected wal_compression={expected}, got '{show}'"
+        finally:
+            host.run(f"{get_psql_binary_path} -c 'ALTER SYSTEM RESET wal_compression;'")
+            host.run(f"{get_psql_binary_path} -c 'SELECT pg_reload_conf();'")
+
+
 @pytest.mark.parametrize(
     "flag",
     [


### PR DESCRIPTION
Add test_wal_compression_algorithms across packages, tarballs, and all docker image variants to confirm pglz (PG14+) and lz4/zstd (PG15+) are accepted by the wal_compression GUC, since support depends on --with-lz4/--with-zstd build flags that can silently drift between packaging pipelines. PG14's wal_compression is a plain boolean GUC (on/off only); the pglz/lz4/zstd enum literals were introduced in PG15.