### PR TITLE
PG-2603 test: skip known lz4/zstd wal_compression gap up to current r…

### DIFF
--- a/ppg/tests/tests_ppg/test_bvt.py
+++ b/ppg/tests/tests_ppg/test_bvt.py
@@ -575,6 +575,30 @@ WAL_COMPRESSION_ALGORITHMS = {
     "zstd": 15,
 }
 
+# These versions were built without --with-zstd for Ubuntu/Debian. This is
+# expected to resolve once the fix reaches the release repo for a future
+# minor version. LZ4 is present on all versions and platforms, but making sure
+# it's not missing from builds is still worthwhile.
+PACKAGE_LZ4_ZSTD_GAP_MAX_VERSION = {
+    14: (14, 23),
+    15: (15, 18),
+    16: (16, 14),
+    17: (17, 10),
+    18: (18, 4),
+}
+
+
+def _skip_lz4_zstd_check():
+    cap = PACKAGE_LZ4_ZSTD_GAP_MAX_VERSION.get(int(settings.MAJOR_VER))
+    if cap is None:
+        return False
+    raw_version = os.getenv("VERSION") or ""
+    after_dash = raw_version.split("-", 1)[1] if "-" in raw_version else raw_version
+    parts = after_dash.split(".")
+    if len(parts) < 2:
+        return True  # major-only run (e.g. "ppg-17"); assume worst case
+    return tuple(int(p) for p in parts[:2]) <= cap
+
 
 @pytest.mark.parametrize("algo", list(WAL_COMPRESSION_ALGORITHMS))
 def test_wal_compression_algorithms(host, algo):
@@ -592,6 +616,11 @@ def test_wal_compression_algorithms(host, algo):
     min_ver = WAL_COMPRESSION_ALGORITHMS[algo]
     if int(settings.MAJOR_VER) < min_ver:
         pytest.skip(f"wal_compression={algo} requires PG{min_ver}+, found {settings.MAJOR_VER}")
+
+    if algo in ("lz4", "zstd") and _skip_lz4_zstd_check():
+        pytest.skip(
+            f"Skipping wal_compression={algo} check on {os.getenv('VERSION')}"
+        )
 
     is_pg14_pglz = algo == "pglz" and int(settings.MAJOR_VER) < 15
     set_value = "on" if is_pg14_pglz else algo

--- a/ppg/tests/tests_ppg_tarballs/test_bvt.py
+++ b/ppg/tests/tests_ppg_tarballs/test_bvt.py
@@ -400,6 +400,28 @@ WAL_COMPRESSION_ALGORITHMS = {
     "zstd": 15,
 }
 
+# The official tarball release, at or below these per-major
+# versions, may be missing --with-zstd, so lz4/zstd are not
+# available (pglz always works, no external lib needed) as this symptom
+# was found in packages for zstd. Just adding a check here to make sure,
+# we're not missing it from builds.
+TARBALL_LZ4_ZSTD_GAP_MAX_VERSION = {
+    14: (14, 23),
+    15: (15, 18),
+    16: (16, 14),
+    17: (17, 10),
+    18: (18, 4),
+}
+
+
+def _skip_lz4_zstd_check():
+    cap = TARBALL_LZ4_ZSTD_GAP_MAX_VERSION.get(int(settings.MAJOR_VER))
+    if cap is None:
+        return False
+    full_version = os.getenv("VERSION").split("-", 1)[1]  # e.g. "17.10"
+    current = tuple(int(p) for p in full_version.split(".")[:2])
+    return current <= cap
+
 
 @pytest.mark.parametrize("algo", list(WAL_COMPRESSION_ALGORITHMS))
 def test_wal_compression_algorithms(host, get_psql_binary_path, algo):
@@ -417,6 +439,11 @@ def test_wal_compression_algorithms(host, get_psql_binary_path, algo):
     min_ver = WAL_COMPRESSION_ALGORITHMS[algo]
     if int(settings.MAJOR_VER) < min_ver:
         pytest.skip(f"wal_compression={algo} requires PG{min_ver}+, found {settings.MAJOR_VER}")
+
+    if algo in ("lz4", "zstd") and _skip_lz4_zstd_check():
+        pytest.skip(
+            f"Skipping wal_compression={algo} check on {os.getenv('VERSION')}"
+        )
 
     is_pg14_pglz = algo == "pglz" and int(settings.MAJOR_VER) < 15
     set_value = "on" if is_pg14_pglz else algo


### PR DESCRIPTION
…eleases

Packages and tarballs at or below 14.23/15.18/16.14/17.10/18.4 were built without zstd on ubuntu, so skip those cases per version, so a regression above these versions still fails instead of being masked.