### PR TITLE
Resolve AZ-fallback subnet/security-group lazily, only on retry

### DIFF
--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -44,18 +44,10 @@
       with_items: "{{ molecule_yml.platforms }}"
       register: subnet_facts
 
-    - name: Check AZ-fallback subnets
-      amazon.aws.ec2_vpc_subnet_info:
-        region: "{{ (molecule_yml.platforms | first).region | default(default_region) }}"
-        filters:
-          subnet-id: "{{ item }}"
-      with_items: "{{ az_fallback_subnet_ids }}"
-      register: fallback_subnet_facts
-
     - name: Populate subnet vpc
       set_fact:
         subnet_dict: "{{ subnet_dict|default({}) | combine({ item.subnets[0].id: item.subnets[0].vpc_id }) }}"
-      with_items: "{{ subnet_facts.results + fallback_subnet_facts.results }}"
+      with_items: "{{ subnet_facts.results }}"
 
     - name: Create security group
       amazon.aws.ec2_security_group:
@@ -67,15 +59,11 @@
         region: "{{ item.region|default(default_region) }}"
       with_items: "{{ molecule_yml.platforms }}"
 
-    - name: Create security group for AZ-fallback VPCs
-      amazon.aws.ec2_security_group:
-        name: "{{ security_group_name_prefix }}-{{ subnet_dict[item] }}"
-        description: "{{ security_group_description }}"
-        rules: "{{ security_group_rules }}"
-        rules_egress: "{{ security_group_rules_egress }}"
-        vpc_id: "{{ subnet_dict[item] }}"
-        region: "{{ (molecule_yml.platforms | first).region | default(default_region) }}"
-      with_items: "{{ az_fallback_subnet_ids }}"
+    # AZ-fallback subnets are resolved lazily, only inside create_instance_retry.yml,
+    # so a normal (non-capacity-failure) run makes zero extra EC2 API calls. Doing
+    # this unconditionally here previously doubled DescribeSubnets/security-group
+    # calls on every parallel molecule run and contributed to RequestLimitExceeded
+    # throttling under psp-check-parallel.
 
 #    - name: Delete remote keypair
 #      ec2_key:

--- a/playbooks/create_instance_retry.yml
+++ b/playbooks/create_instance_retry.yml
@@ -4,6 +4,30 @@
 # platform dict) and retry_candidates (remaining subnet ids to try, in order).
 # Ansible loops can't "break" on first success without spawning every remaining
 # item too, so early-exit is simulated via recursion instead.
+- name: "Resolve VPC for AZ-fallback subnet {{ retry_candidates[0] }}"
+  amazon.aws.ec2_vpc_subnet_info:
+    region: "{{ retry_platform.region | default(default_region) }}"
+    filters:
+      subnet-id: "{{ retry_candidates[0] }}"
+  register: fallback_subnet_info
+  when: retry_candidates[0] not in subnet_dict
+
+- name: "Record VPC for AZ-fallback subnet {{ retry_candidates[0] }}"
+  set_fact:
+    subnet_dict: "{{ subnet_dict | combine({ retry_candidates[0]: fallback_subnet_info.subnets[0].vpc_id }) }}"
+  when: retry_candidates[0] not in subnet_dict
+
+- name: "Ensure security group exists for AZ-fallback subnet {{ retry_candidates[0] }}"
+  # Idempotent (ensures/returns the existing group), and this whole file only
+  # runs on the rare capacity-retry path, so no gating needed to save calls here.
+  amazon.aws.ec2_security_group:
+    name: "{{ security_group_name_prefix }}-{{ subnet_dict[retry_candidates[0]] }}"
+    description: "{{ security_group_description }}"
+    rules: "{{ security_group_rules }}"
+    rules_egress: "{{ security_group_rules_egress }}"
+    vpc_id: "{{ subnet_dict[retry_candidates[0]] }}"
+    region: "{{ retry_platform.region | default(default_region) }}"
+
 - name: "Retry create instance for {{ retry_platform.name }} in subnet {{ retry_candidates[0] }}"
   amazon.aws.ec2_instance:
     key_name: "{{ keypair_name }}"


### PR DESCRIPTION
Checking all 3 AZ subnets and creating their security groups unconditionally on every molecule create run doubled EC2 API calls across every parallel psp-check-parallel job, tipping the account into RequestLimitExceeded (DescribeSecurityGroups) during a normal run. Move that resolution into create_instance_retry.yml so it only happens when a capacity failure actually triggers a fallback, restoring the original API call volume on the happy path.