### PR TITLE
Set global dnf kernel exclude instead of patching each call site

### DIFF
--- a/docker/ppg-docker-custom-upgrade/tasks/main.yml
+++ b/docker/ppg-docker-custom-upgrade/tasks/main.yml
@@ -41,7 +41,12 @@
 
 - name: Yum update
   become: true
-  command: yum -y update
+  # --exclude=kernel*: kernel-modules-extra below is pinned to ansible_kernel
+  # (the currently running kernel), not "latest", and nothing here reboots —
+  # so this role never needs a kernel bump, but the small cloud-image /boot
+  # partition can't fit old+new kernel at once mid-transaction (see the
+  # identical fix in playbooks/prepare.yml).
+  command: yum -y update --exclude=kernel*
   when: ansible_os_family == "RedHat"
 
 - name: Ensure required dependencies are installed
@@ -57,6 +62,9 @@
   dnf:
     name: "kernel-modules-extra-{{ ansible_kernel }}"
     state: present
+    # prepare.yml sets a global exclude=kernel* in /etc/dnf/dnf.conf; override
+    # it here since this package name matches that glob.
+    disable_excludes: main
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "10"
 
 - name: Ensure br_netfilter module is loaded (RHEL 10 only)
@@ -72,7 +80,10 @@
 
 - name: Yum update
   become: true
-  command: yum -y update
+  # Refreshes metadata for the Docker CE repo just added above — not a
+  # system update, so use makecache rather than "yum -y update" (which
+  # can hit the same /boot-space kernel issue fixed above).
+  command: yum makecache
   when: ansible_os_family == "RedHat"
 
 - name: Install python3-psycopg2

--- a/docker/ppg-docker-custom/tasks/main.yml
+++ b/docker/ppg-docker-custom/tasks/main.yml
@@ -23,7 +23,12 @@
 
 - name: Yum update
   become: true
-  command: yum -y update
+  # --exclude=kernel*: kernel-modules-extra below is pinned to ansible_kernel
+  # (the currently running kernel), not "latest", and nothing here reboots —
+  # so this role never needs a kernel bump, but the small cloud-image /boot
+  # partition can't fit old+new kernel at once mid-transaction (see the
+  # identical fix in playbooks/prepare.yml).
+  command: yum -y update --exclude=kernel*
   when: ansible_os_family == "RedHat"
 
 - name: Ensure required dependencies are installed
@@ -39,6 +44,9 @@
   dnf:
     name: "kernel-modules-extra-{{ ansible_kernel }}"
     state: present
+    # prepare.yml sets a global exclude=kernel* in /etc/dnf/dnf.conf; override
+    # it here since this package name matches that glob.
+    disable_excludes: main
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "10"
 
 - name: Ensure br_netfilter module is loaded (RHEL 10 only)
@@ -54,7 +62,10 @@
 
 - name: Yum update
   become: true
-  command: yum -y update
+  # Refreshes metadata for the Docker CE repo just added above — not a
+  # system update, so use makecache rather than "yum -y update" (which
+  # can hit the same /boot-space kernel issue fixed above).
+  command: yum makecache
   when: ansible_os_family == "RedHat"
 
 - name: Install python3-psycopg2

--- a/docker/ppg-docker-upgrade/tasks/main.yml
+++ b/docker/ppg-docker-upgrade/tasks/main.yml
@@ -42,7 +42,12 @@
 
 - name: Yum update
   become: true
-  command: yum -y update
+  # --exclude=kernel*: kernel-modules-extra below is pinned to ansible_kernel
+  # (the currently running kernel), not "latest", and nothing here reboots —
+  # so this role never needs a kernel bump, but the small cloud-image /boot
+  # partition can't fit old+new kernel at once mid-transaction (see the
+  # identical fix in playbooks/prepare.yml).
+  command: yum -y update --exclude=kernel*
   when: ansible_os_family == "RedHat"
 
 - name: Ensure required dependencies are installed
@@ -58,6 +63,9 @@
   dnf:
     name: "kernel-modules-extra-{{ ansible_kernel }}"
     state: present
+    # prepare.yml sets a global exclude=kernel* in /etc/dnf/dnf.conf; override
+    # it here since this package name matches that glob.
+    disable_excludes: main
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "10"
 
 - name: Ensure br_netfilter module is loaded (RHEL 10 only)
@@ -73,7 +81,10 @@
 
 - name: Yum update
   become: true
-  command: yum -y update
+  # Refreshes metadata for the Docker CE repo just added above — not a
+  # system update, so use makecache rather than "yum -y update" (which
+  # can hit the same /boot-space kernel issue fixed above).
+  command: yum makecache
   when: ansible_os_family == "RedHat"
 
 - name: Install python3-psycopg2

--- a/docker/ppg-docker/tasks/main.yml
+++ b/docker/ppg-docker/tasks/main.yml
@@ -28,7 +28,12 @@
 
 - name: Yum update
   become: true
-  command: yum -y update
+  # --exclude=kernel*: kernel-modules-extra below is pinned to ansible_kernel
+  # (the currently running kernel), not "latest", and nothing here reboots —
+  # so this role never needs a kernel bump, but the small cloud-image /boot
+  # partition can't fit old+new kernel at once mid-transaction (see the
+  # identical fix in playbooks/prepare.yml).
+  command: yum -y update --exclude=kernel*
   when: ansible_os_family == "RedHat"
 
 - name: Ensure required dependencies are installed
@@ -44,6 +49,9 @@
   dnf:
     name: "kernel-modules-extra-{{ ansible_kernel }}"
     state: present
+    # prepare.yml sets a global exclude=kernel* in /etc/dnf/dnf.conf; override
+    # it here since this package name matches that glob.
+    disable_excludes: main
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "10"
 
 - name: Ensure br_netfilter module is loaded (RHEL 10 only)
@@ -59,7 +67,10 @@
 
 - name: Yum update
   become: true
-  command: yum -y update
+  # Refreshes metadata for the Docker CE repo just added above — not a
+  # system update, so use makecache rather than "yum -y update" (which
+  # can hit the same /boot-space kernel issue fixed above).
+  command: yum makecache
   when: ansible_os_family == "RedHat"
 
 - name: Install python3-psycopg2

--- a/pg_tde/auxiliary/tasks/install_docker.yml
+++ b/pg_tde/auxiliary/tasks/install_docker.yml
@@ -30,10 +30,11 @@
 
 # Docker's bridge network needs the br_netfilter and xt_addrtype kernel
 # modules, shipped in kernel-modules-extra matched to the *running* kernel.
-# prepare.yml excludes kernel* from its general update (a too-small /boot on
-# most roles' base images can't fit old+new kernel at once, and no other
-# role needs a kernel bump) — so this role updates its own kernel explicitly,
-# right where it's needed. Without this, the box still runs the old kernel
+# prepare.yml sets a global exclude=kernel* in /etc/dnf/dnf.conf (a too-small
+# /boot on most roles' base images can't fit old+new kernel at once, and no
+# other role needs a kernel bump) — so this role updates its own kernel
+# explicitly, right where it's needed, overriding that exclude with
+# --disableexcludes=main. Without this, the box still runs the old kernel
 # and those modules are missing on disk, so dockerd fails to register the
 # bridge driver. We bump the kernel, install the latest kernel-modules-extra,
 # and reboot into the matching kernel.
@@ -41,7 +42,7 @@
 # package, so the install is best-effort there and the reboot is scoped out.
 - name: Update kernel packages on EL10 (needed for matching kernel-modules-extra below)
   become: true
-  ansible.builtin.shell: dnf update -y --nobest kernel*
+  ansible.builtin.shell: dnf update -y --nobest --disableexcludes=main kernel*
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "10"
 
 - name: Install kernel-modules-extra (latest) on EL10
@@ -49,6 +50,7 @@
   ansible.builtin.dnf:
     name: kernel-modules-extra
     state: latest
+    disable_excludes: main
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "10"
   ignore_errors: true
 

--- a/playbooks/prepare.yml
+++ b/playbooks/prepare.yml
@@ -5,6 +5,25 @@
   become_method: sudo
   gather_facts: true
   tasks:
+    # dnf will opportunistically pull in a kernel bump as a side effect of
+    # almost any package install (weak/transitive deps, "keep consistent"
+    # resolution) — we've hit this via the general update, a plain package
+    # install, and a "yum cache refresh" alike, each hitting the same
+    # too-small cloud-image /boot partition (can't hold old+new kernel at
+    # once mid-transaction). Patching individual tasks doesn't scale, so
+    # exclude kernel* globally for every dnf/yum call for the rest of this
+    # ephemeral VM's life, set before any other yum/dnf task runs. Nothing
+    # in this suite reboots or checks kernel version except pg_tde/auxiliary's
+    # EL10 Docker setup, which explicitly overrides this with
+    # --disableexcludes=main where it genuinely needs a newer kernel.
+    - name: Exclude kernel packages from all dnf/yum transactions on this VM
+      become: true
+      ansible.builtin.lineinfile:
+        path: /etc/dnf/dnf.conf
+        line: exclude=kernel*
+        insertafter: '^\[main\]'
+      when: ansible_os_family == "RedHat"
+
     # Rocky's default baseos/appstream/crb repos resolve mirrors through the
     # mirrorlist service, which is unreliable on Rocky 10 (esp. aarch64) and
     # fails with "No URLs in mirrorlist". Pin them to the canonical CDN baseurl


### PR DESCRIPTION
Individual --exclude=kernel* fixes on specific tasks kept missing new call sites (e.g. pg_tde/auxiliary's plain package install pulling in a kernel-debug-core bump via a weak dependency). Set exclude=kernel* once in /etc/dnf/dnf.conf at the start of prepare.yml so it covers every yum/dnf call on the box, with explicit disable_excludes/ --disableexcludes=main overrides only where a kernel bump is genuinely needed (pg_tde/auxiliary's EL10 Docker networking, and the kernel-modules-extra installs whose package name matches the glob).