### PR TITLE
Revert prepare.yml and install_docker.yml kernel-exclude changes

### DIFF
--- a/pg_tde/auxiliary/tasks/install_docker.yml
+++ b/pg_tde/auxiliary/tasks/install_docker.yml
@@ -1,12 +1,7 @@
 
 - name: Update yum cache before Docker setup
   become: true
-  # Was "yum -y update" — a full system update, not a cache refresh. That
-  # pulled in kernel packages unscoped, which can hit the same too-small
-  # /boot failure that prepare.yml now avoids via --exclude=kernel* (see
-  # playbooks/prepare.yml). makecache is what "update the cache" actually
-  # means here.
-  command: yum makecache
+  command: yum -y update
   when: ansible_os_family == "RedHat"
 
 - name: Ensure required dependencies are installed
@@ -30,27 +25,17 @@
 
 # Docker's bridge network needs the br_netfilter and xt_addrtype kernel
 # modules, shipped in kernel-modules-extra matched to the *running* kernel.
-# prepare.yml sets a global exclude=kernel* in /etc/dnf/dnf.conf (a too-small
-# /boot on most roles' base images can't fit old+new kernel at once, and no
-# other role needs a kernel bump) — so this role updates its own kernel
-# explicitly, right where it's needed, overriding that exclude with
-# --disableexcludes=main. Without this, the box still runs the old kernel
-# and those modules are missing on disk, so dockerd fails to register the
-# bridge driver. We bump the kernel, install the latest kernel-modules-extra,
-# and reboot into the matching kernel.
+# prepare.yml runs `dnf update`, which installs a newer kernel; without a
+# reboot the box still runs the old kernel and those modules are missing on
+# disk, so dockerd fails to register the bridge driver. We install the latest
+# kernel-modules-extra and reboot into the matching kernel.
 # OL 10 (UEK) already has these modules built in and has no kernel-modules-extra
 # package, so the install is best-effort there and the reboot is scoped out.
-- name: Update kernel packages on EL10 (needed for matching kernel-modules-extra below)
-  become: true
-  ansible.builtin.shell: dnf update -y --nobest --disableexcludes=main kernel*
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "10"
-
 - name: Install kernel-modules-extra (latest) on EL10
   become: true
   ansible.builtin.dnf:
     name: kernel-modules-extra
     state: latest
-    disable_excludes: main
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "10"
   ignore_errors: true
 
@@ -102,8 +87,7 @@
 
 - name: Update yum cache after adding Docker repo
   become: true
-  # Was "yum -y update" — see the identical fix above for why that's wrong here.
-  command: yum makecache
+  command: yum -y update
   when: ansible_os_family == "RedHat"
 
 - name: Install Docker packages

--- a/playbooks/prepare.yml
+++ b/playbooks/prepare.yml
@@ -5,37 +5,6 @@
   become_method: sudo
   gather_facts: true
   tasks:
-    # dnf will opportunistically pull in a kernel bump as a side effect of
-    # almost any package install (weak/transitive deps, "keep consistent"
-    # resolution) — we've hit this via the general update, a plain package
-    # install, and a "yum cache refresh" alike, each hitting the same
-    # too-small cloud-image /boot partition (can't hold old+new kernel at
-    # once mid-transaction). Patching individual tasks doesn't scale, so
-    # exclude the bootable-kernel packages globally for every dnf/yum call
-    # for the rest of this ephemeral VM's life, set before any other yum/dnf
-    # task runs. Nothing in this suite reboots or checks kernel version
-    # except pg_tde/auxiliary's EL10 Docker setup, which explicitly overrides
-    # this with --disableexcludes=main where it genuinely needs a newer kernel.
-    #
-    # Deliberately NOT a "kernel*" glob: that also matched kernel-headers and
-    # kernel-srpm-macros, which are build-time packages (not part of the
-    # running kernel image, don't touch /boot) required by the standard
-    # gcc/glibc-devel/perl-devel toolchain. Excluding them broke every
-    # compiler-toolchain install on RHEL/Rocky/OL 8, 9, and 10 with a dnf
-    # depsolve error. List only the packages that actually land in /boot.
-    - name: Exclude kernel packages from all dnf/yum transactions on this VM
-      become: true
-      ansible.builtin.lineinfile:
-        path: /etc/dnf/dnf.conf
-        line: >-
-          exclude=kernel kernel-core kernel-modules kernel-modules-core
-          kernel-modules-extra kernel-debug kernel-debug-core
-          kernel-debug-modules kernel-debug-modules-core
-          kernel-debug-modules-extra kernel-tools kernel-tools-libs
-          kernel-uki-virt kernel-debug-uki-virt
-        insertafter: '^\[main\]'
-      when: ansible_os_family == "RedHat"
-
     # Rocky's default baseos/appstream/crb repos resolve mirrors through the
     # mirrorlist service, which is unreliable on Rocky 10 (esp. aarch64) and
     # fails with "No URLs in mirrorlist". Pin them to the canonical CDN baseurl
@@ -177,14 +146,7 @@
       # version-locked subpackage (e.g. glibc vs glibc-gconv-extra) are
       # published out of sync. Falls back to the largest consistent version
       # set instead of failing on a "best" candidate that has no partner.
-      # --exclude=kernel*: these are ephemeral test instances that never
-      # reboot and nothing in this suite checks the kernel version, but the
-      # default cloud-image /boot partition is too small to hold old+new
-      # kernel at once mid-transaction (dnf update -y --nobest fails with
-      # "needs N more space on the /boot filesystem"). Skip kernel packages
-      # entirely rather than resizing /boot for a VM that gets destroyed
-      # at the end of the run.
-      ansible.builtin.shell: dnf update -y --nobest --exclude=kernel*
+      ansible.builtin.shell: dnf update -y --nobest
       when: ansible_os_family == "RedHat"
 
     - name: Enable Powertools on Rocky 8


### PR DESCRIPTION
Back to 01d4ed68's behavior: plain "dnf update -y --nobest" in prepare.yml with no /etc/dnf/dnf.conf exclude, and the original bare kernel-modules-extra / state: latest install in pg_tde/auxiliary/tasks/install_docker.yml with no explicit kernel bump/disable_excludes and the original task ordering.