### PR TITLE
Revert kernel-exclude changes; keep the yum-cache-refresh fix

### DIFF
--- a/docker/ppg-docker-custom-upgrade/tasks/main.yml
+++ b/docker/ppg-docker-custom-upgrade/tasks/main.yml
@@ -41,12 +41,7 @@
 
 - name: Yum update
   become: true
-  # --exclude=kernel*: kernel-modules-extra below is pinned to ansible_kernel
-  # (the currently running kernel), not "latest", and nothing here reboots —
-  # so this role never needs a kernel bump, but the small cloud-image /boot
-  # partition can't fit old+new kernel at once mid-transaction (see the
-  # identical fix in playbooks/prepare.yml).
-  command: yum -y update --exclude=kernel*
+  command: yum -y update
   when: ansible_os_family == "RedHat"
 
 - name: Ensure required dependencies are installed
@@ -62,9 +57,6 @@
   dnf:
     name: "kernel-modules-extra-{{ ansible_kernel }}"
     state: present
-    # prepare.yml sets a global exclude=kernel* in /etc/dnf/dnf.conf; override
-    # it here since this package name matches that glob.
-    disable_excludes: main
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "10"
 
 - name: Ensure br_netfilter module is loaded (RHEL 10 only)
@@ -81,8 +73,7 @@
 - name: Yum update
   become: true
   # Refreshes metadata for the Docker CE repo just added above — not a
-  # system update, so use makecache rather than "yum -y update" (which
-  # can hit the same /boot-space kernel issue fixed above).
+  # system update, so use makecache rather than "yum -y update".
   command: yum makecache
   when: ansible_os_family == "RedHat"
 

--- a/docker/ppg-docker-custom/tasks/main.yml
+++ b/docker/ppg-docker-custom/tasks/main.yml
@@ -23,12 +23,7 @@
 
 - name: Yum update
   become: true
-  # --exclude=kernel*: kernel-modules-extra below is pinned to ansible_kernel
-  # (the currently running kernel), not "latest", and nothing here reboots —
-  # so this role never needs a kernel bump, but the small cloud-image /boot
-  # partition can't fit old+new kernel at once mid-transaction (see the
-  # identical fix in playbooks/prepare.yml).
-  command: yum -y update --exclude=kernel*
+  command: yum -y update
   when: ansible_os_family == "RedHat"
 
 - name: Ensure required dependencies are installed
@@ -44,9 +39,6 @@
   dnf:
     name: "kernel-modules-extra-{{ ansible_kernel }}"
     state: present
-    # prepare.yml sets a global exclude=kernel* in /etc/dnf/dnf.conf; override
-    # it here since this package name matches that glob.
-    disable_excludes: main
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "10"
 
 - name: Ensure br_netfilter module is loaded (RHEL 10 only)
@@ -63,8 +55,7 @@
 - name: Yum update
   become: true
   # Refreshes metadata for the Docker CE repo just added above — not a
-  # system update, so use makecache rather than "yum -y update" (which
-  # can hit the same /boot-space kernel issue fixed above).
+  # system update, so use makecache rather than "yum -y update".
   command: yum makecache
   when: ansible_os_family == "RedHat"
 

--- a/docker/ppg-docker-upgrade/tasks/main.yml
+++ b/docker/ppg-docker-upgrade/tasks/main.yml
@@ -42,12 +42,7 @@
 
 - name: Yum update
   become: true
-  # --exclude=kernel*: kernel-modules-extra below is pinned to ansible_kernel
-  # (the currently running kernel), not "latest", and nothing here reboots —
-  # so this role never needs a kernel bump, but the small cloud-image /boot
-  # partition can't fit old+new kernel at once mid-transaction (see the
-  # identical fix in playbooks/prepare.yml).
-  command: yum -y update --exclude=kernel*
+  command: yum -y update
   when: ansible_os_family == "RedHat"
 
 - name: Ensure required dependencies are installed
@@ -63,9 +58,6 @@
   dnf:
     name: "kernel-modules-extra-{{ ansible_kernel }}"
     state: present
-    # prepare.yml sets a global exclude=kernel* in /etc/dnf/dnf.conf; override
-    # it here since this package name matches that glob.
-    disable_excludes: main
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "10"
 
 - name: Ensure br_netfilter module is loaded (RHEL 10 only)
@@ -82,8 +74,7 @@
 - name: Yum update
   become: true
   # Refreshes metadata for the Docker CE repo just added above — not a
-  # system update, so use makecache rather than "yum -y update" (which
-  # can hit the same /boot-space kernel issue fixed above).
+  # system update, so use makecache rather than "yum -y update".
   command: yum makecache
   when: ansible_os_family == "RedHat"
 

--- a/docker/ppg-docker/tasks/main.yml
+++ b/docker/ppg-docker/tasks/main.yml
@@ -28,12 +28,7 @@
 
 - name: Yum update
   become: true
-  # --exclude=kernel*: kernel-modules-extra below is pinned to ansible_kernel
-  # (the currently running kernel), not "latest", and nothing here reboots —
-  # so this role never needs a kernel bump, but the small cloud-image /boot
-  # partition can't fit old+new kernel at once mid-transaction (see the
-  # identical fix in playbooks/prepare.yml).
-  command: yum -y update --exclude=kernel*
+  command: yum -y update
   when: ansible_os_family == "RedHat"
 
 - name: Ensure required dependencies are installed
@@ -49,9 +44,6 @@
   dnf:
     name: "kernel-modules-extra-{{ ansible_kernel }}"
     state: present
-    # prepare.yml sets a global exclude=kernel* in /etc/dnf/dnf.conf; override
-    # it here since this package name matches that glob.
-    disable_excludes: main
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "10"
 
 - name: Ensure br_netfilter module is loaded (RHEL 10 only)
@@ -68,8 +60,7 @@
 - name: Yum update
   become: true
   # Refreshes metadata for the Docker CE repo just added above — not a
-  # system update, so use makecache rather than "yum -y update" (which
-  # can hit the same /boot-space kernel issue fixed above).
+  # system update, so use makecache rather than "yum -y update".
   command: yum makecache
   when: ansible_os_family == "RedHat"
 


### PR DESCRIPTION
Root cause (Rocky/RHEL /boot partition sizing) is now fixed upstream by the platform team, so revert these 4 files' --exclude=kernel*/ disable_excludes additions from 40ac2da9 back to bdebedb5's plain "yum -y update" and let the platform own that invariant instead of duplicating a defense for it here.

Kept one independent piece: the second "Yum update" task in each file (right after adding the Docker CE repo) is only ever meant to refresh repo metadata, not run a full system update, so it stays as "yum makecache" rather than reverting to "yum -y update" there too.