### PR TITLE
Fix pg_oidc_validator loaded-module version test session bug

### DIFF
--- a/ppg/tests/tests_ppg/test_tools.py
+++ b/ppg/tests/tests_ppg/test_tools.py
@@ -1726,12 +1726,13 @@ def test_pg_oidc_validator_loaded_module_version(host):
 
     psql = "psql -t -A -c"
     with host.sudo("postgres"):
-        result = host.run(f"{psql} \"LOAD 'pg_oidc_validator';\"")
-        assert result.rc == 0, f"failed to LOAD pg_oidc_validator: {result.stderr}"
-
+        # LOAD and the SELECT must run in the same session -- LOAD only
+        # loads the module into the backend that issues it, and a separate
+        # `psql` invocation would open a fresh connection where the module
+        # was never loaded.
         result = host.run(
-            f"{psql} \"SELECT version FROM pg_get_loaded_modules() "
-            f"WHERE module_name = 'pg_oidc_validator';\""
+            f"{psql} \"LOAD 'pg_oidc_validator'; SELECT version FROM "
+            f"pg_get_loaded_modules() WHERE module_name = 'pg_oidc_validator';\""
         )
         assert result.rc == 0, f"failed to query pg_get_loaded_modules(): {result.stderr}"
         assert result.stdout.strip() == expected_version, (


### PR DESCRIPTION
LOAD 'pg_oidc_validator' and the SELECT from pg_get_loaded_modules() ran as two separate host.run() calls, each spawning its own psql process -- i.e. a fresh backend connection. LOAD only loads a module into the session that issued it, so the second connection's query correctly found nothing, failing with "expected 1.1.0, got ''" on Debian/Ubuntu where pg_oidc_validator isn't in
shared_preload_libraries and is genuinely lazy-loaded per-session.

Combine both statements into a single psql invocation so they share one session. Verified live in a PG18 container: reproduced the exact empty-string failure with the old two-call approach, confirmed the fix returns 1.1.0.