### PR TITLE
pg_tde/tde: source gcc-toolset-14 on RHEL 8 in meson setup and compil…

### DIFF
--- a/pg_tde/tde/tasks/main.yml
+++ b/pg_tde/tde/tasks/main.yml
@@ -305,7 +305,7 @@
   become: true
   become_user: postgres
   ansible.builtin.shell: |
-    {% if ansible_os_family == 'RedHat' and ansible_distribution_major_version == '9' %}
+    {% if ansible_os_family == 'RedHat' and ansible_distribution_major_version in ['8', '9'] %}
     source /opt/rh/gcc-toolset-14/enable
     {% endif %}
     set -o pipefail
@@ -338,7 +338,7 @@
   become: true
   become_user: postgres
   ansible.builtin.shell: |
-    {% if ansible_os_family == 'RedHat' and ansible_distribution_major_version == '9' %}
+    {% if ansible_os_family == 'RedHat' and ansible_distribution_major_version in ['8', '9'] %}
     source /opt/rh/gcc-toolset-14/enable
     {% endif %}
     set -o pipefail


### PR DESCRIPTION
…e tasks

The Jinja2 condition gating gcc-toolset-14 activation only matched RHEL 9; RHEL/OL/Rocky 8 builds against installed packages were still using GCC 8.5 which lacks <span>, causing libkmip to fail. Extend both the setup and compile conditions to cover major version 8 and 9.